### PR TITLE
Add issue severity enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ DemoCheckerBundle.exampleChecker.testCheckerParam = Foo
 - Create a file `main.py` with:
 
 ```python
-from qc_baselib import Report
+from qc_baselib import Report, IssueSeverity
 
 def main():
     report = Report()
@@ -191,7 +191,7 @@ def main():
         checker_id="TestChecker",
         issue_id=0,
         description="Issue found at odr",
-        level=3,
+        level=IssueSeverity.INFORMATION,
     )
 
     report.add_file_location_to_issue(

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ poetry install
 - Create a file `main.py` with:
 
 ```python
-from qc_baselib import Configuration
+from qc_baselib import Configuration, IssueSeverity
 
 def main():
     config = Configuration()
@@ -53,8 +53,8 @@ def main():
     config.register_checker_to_bundle(
         application="TestCheckerBundle",
         checker_id="TestChecker",
-        min_level=1,
-        max_level=3,
+        min_level=IssueSeverity.ERROR,
+        max_level=IssueSeverity.INFORMATION,
     )
 
     # Creating using named arguments

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -8,4 +8,4 @@ __version__ = "0.1.0"
 
 from .configuration import Configuration as Configuration
 from .report import Report as Report
-from .models.report import IssueSeverity
+from .models.report import IssueSeverity as IssueSeverity

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -8,3 +8,4 @@ __version__ = "0.1.0"
 
 from .configuration import Configuration as Configuration
 from .report import Report as Report
+from .models.report import IssueSeverity

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -8,4 +8,4 @@ __version__ = "0.1.0"
 
 from .configuration import Configuration as Configuration
 from .report import Report as Report
-from .models.report import IssueSeverity as IssueSeverity
+from .models import IssueSeverity as IssueSeverity

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -4,7 +4,7 @@
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from typing import Union
-from .models import config, common
+from .models import config, common, IssueSeverity
 
 
 class Configuration:
@@ -187,7 +187,11 @@ class Configuration:
             self._configuration.checker_bundles.append(checker_bundle)
 
     def register_checker_to_bundle(
-        self, application: str, checker_id: str, min_level: str, max_level: str
+        self,
+        application: str,
+        checker_id: str,
+        min_level: IssueSeverity,
+        max_level: IssueSeverity,
     ) -> None:
         check = config.CheckerType(
             checker_id=checker_id, min_level=min_level, max_level=max_level

--- a/qc_baselib/models/__init__.py
+++ b/qc_baselib/models/__init__.py
@@ -1,1 +1,1 @@
-from .report import IssueSeverity as IssueSeverity
+from .common import IssueSeverity as IssueSeverity

--- a/qc_baselib/models/__init__.py
+++ b/qc_baselib/models/__init__.py
@@ -1,0 +1,1 @@
+from .report import IssueSeverity as IssueSeverity

--- a/qc_baselib/models/common.py
+++ b/qc_baselib/models/common.py
@@ -2,10 +2,17 @@
 # This Source Code Form is subject to the terms of the Mozilla
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import enum
 
 from typing import Annotated, Union
 from pydantic import Field
 from pydantic_xml import BaseXmlModel, attr
+
+
+class IssueSeverity(enum.IntEnum):
+    ERROR = 1
+    WARNING = 2
+    INFORMATION = 3
 
 
 # Common types for both schemas

--- a/qc_baselib/models/config.py
+++ b/qc_baselib/models/config.py
@@ -7,7 +7,7 @@ from typing import List, Any
 from pydantic import model_validator
 from pydantic_xml import BaseXmlModel, attr
 
-from .common import ParamType
+from .common import ParamType, IssueSeverity
 
 # Configuration models
 # Original XSD file:

--- a/qc_baselib/models/report.py
+++ b/qc_baselib/models/report.py
@@ -2,12 +2,20 @@
 # This Source Code Form is subject to the terms of the Mozilla
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import enum
 
 from typing import List, Any
 from pydantic import model_validator
 from pydantic_xml import BaseXmlModel, attr
 
 from .common import ParamType
+
+
+class IssueSeverity(enum.Enum):
+    ERROR = 1
+    WARNING = 2
+    INFORMATION = 3
+
 
 # Report models
 # Original XSD file:

--- a/qc_baselib/models/report.py
+++ b/qc_baselib/models/report.py
@@ -2,19 +2,11 @@
 # This Source Code Form is subject to the terms of the Mozilla
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
-import enum
-
 from typing import List, Any
 from pydantic import model_validator
 from pydantic_xml import BaseXmlModel, attr
 
-from .common import ParamType
-
-
-class IssueSeverity(enum.IntEnum):
-    ERROR = 1
-    WARNING = 2
-    INFORMATION = 3
+from .common import ParamType, IssueSeverity
 
 
 # Report models

--- a/qc_baselib/models/report.py
+++ b/qc_baselib/models/report.py
@@ -11,7 +11,7 @@ from pydantic_xml import BaseXmlModel, attr
 from .common import ParamType
 
 
-class IssueSeverity(enum.Enum):
+class IssueSeverity(enum.IntEnum):
     ERROR = 1
     WARNING = 2
     INFORMATION = 3
@@ -60,7 +60,7 @@ class IssueType(BaseXmlModel, tag="Issue"):
     locations: List[LocationType] = []
     issue_id: int = attr(name="issueId")
     description: str = attr(name="description")
-    level: int = attr(name="level")
+    level: IssueSeverity = attr(name="level")
 
 
 class CheckerType(BaseXmlModel, tag="Checker"):

--- a/qc_baselib/report.py
+++ b/qc_baselib/report.py
@@ -179,7 +179,7 @@ class Report:
         checker_id: str,
         issue_id: int,
         description: str,
-        level: int,
+        level: report.IssueSeverity,
     ) -> None:
         issue = report.IssueType(
             issue_id=issue_id, description=description, level=level

--- a/qc_baselib/report.py
+++ b/qc_baselib/report.py
@@ -4,7 +4,7 @@
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from typing import Union
-from .models import report
+from .models import report, IssueSeverity
 
 REPORT_OUTPUT_FORMAT = "xqar"
 DEFAULT_REPORT_VERSION = "0.0.1"
@@ -179,7 +179,7 @@ class Report:
         checker_id: str,
         issue_id: int,
         description: str,
-        level: report.IssueSeverity,
+        level: IssueSeverity,
     ) -> None:
         issue = report.IssueType(
             issue_id=issue_id, description=description, level=level

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from qc_baselib.models import config, report
-from qc_baselib import Report
+from qc_baselib import Report, IssueSeverity
 
 
 DEMO_REPORT_PATH = "tests/data/demo_checker_bundle.xqar"
@@ -48,7 +48,7 @@ def test_report_write() -> None:
         checker_id="TestChecker",
         issue_id=0,
         description="Issue found at odr",
-        level=3,
+        level=IssueSeverity.INFORMATION,
     )
 
     report.add_file_location_to_issue(


### PR DESCRIPTION
**Description**

This PR adds a enumerator for the issue severity as a model for user help.

**Main changes**

1. [Add IssueSeverity enum](https://github.com/asam-ev/qc-baselib-py/commit/496d7030b21631567e78d81205d7f86efa7340b6)
2. [Add test using new enum](https://github.com/asam-ev/qc-baselib-py/commit/0e3b3ec0ef0bdfe5b58806a3d3e9d3ac7ce242a5)

**How was the PR tested?**

1. Unit-test passing with the addition of the enum.

**Notes**
- None.