### PR TITLE
Support the new result file schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,9 @@ def main():
         rule_full_name="qwerty.qwerty",
     )
 
-    result.register_issue(
+    issue_id = result.register_issue(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",
-        issue_id=0,
         description="Issue found at odr",
         level=IssueSeverity.INFORMATION,
         rule_uid=rule_uid,
@@ -214,7 +213,7 @@ def main():
     result.add_file_location(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",
-        issue_id=0,
+        issue_id=issue_id,
         row=1,
         column=0,
         file_type="odr",

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Issue id: 0
 Issue level: 3
 ```
 
+For more use case examples refer to the library [tests](tests/).
+
 ## Tests
 
 - Install module on development mode

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ From Pypi:
 pip install qc_baselib
 ```
 
+From Github repository:
+
+```bash
+pip install qc_baselib @ git+https://github.com/asam-ev/qc-baselib-py@main
+```
+
 Locally for developing using [Poetry](https://python-poetry.org/):
 
 ```bash
@@ -187,12 +193,22 @@ def main():
         summary="Executed evaluation",
     )
 
+    rule_uid = result.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        emanating_entity="test.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="qwerty.qwerty",
+    )
+
     result.register_issue(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",
         issue_id=0,
         description="Issue found at odr",
         level=IssueSeverity.INFORMATION,
+        rule_uid=rule_uid,
     )
 
     result.add_file_location(
@@ -204,7 +220,6 @@ def main():
         file_type="odr",
         description="Location for issue",
     )
-    # xml location are also supported
 
     result.write_to_file("testResults.xqar")
 

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -9,3 +9,4 @@ __version__ = "0.1.0"
 from .configuration import Configuration as Configuration
 from .result import Result as Result
 from .models import IssueSeverity as IssueSeverity
+from .models import StatusType as StatusType

--- a/qc_baselib/models/__init__.py
+++ b/qc_baselib/models/__init__.py
@@ -1,1 +1,2 @@
 from .common import IssueSeverity as IssueSeverity
+from .result import StatusType as StatusType

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -58,16 +58,19 @@ class RuleType(BaseXmlModel, tag="AddressedRule"):
         https://github.com/asam-ev/qc-framework/blob/develop/doc/manual/rule_uid_schema.md
     """
 
+    # The current implementation makes Rule members required, so no element can
+    # be left empty for the uid composition.
+
     emanating_entity: str = attr(
         name="emanating_entity", default="", pattern=r"^((\w+(\.\w+)+))$", exclude=True
     )
     standard: str = attr(
-        name="standard", default="", pattern=r"^(([a-z]+))?$", exclude=True
+        name="standard", default="", pattern=r"^(([a-z]+))$", exclude=True
     )
     definition_setting: str = attr(
         name="definition_setting",
         default="",
-        pattern=r"^(([0-9]+(\.[0-9]+)+))?$",
+        pattern=r"^(([0-9]+(\.[0-9]+)+))$",
         exclude=True,
     )
     rule_full_name: str = attr(

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -152,9 +152,7 @@ class CheckerType(BaseXmlModel, tag="Checker", validate_assignment=True):
     addressed_rule: List[RuleType] = []
     issues: List[IssueType] = []
     metadata: List[MetadataType] = []
-    status: StatusType = attr(
-        name="status", default=StatusType.SKIPPED
-    )  # = "" optional
+    status: StatusType = attr(name="status", default="")
     checker_id: str = attr(name="checkerId")
     description: str = attr(name="description")
     summary: str = attr(name="summary")

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -21,9 +21,9 @@ class XMLLocationType(BaseXmlModel, tag="XMLLocation"):
 
 
 class InertialLocationType(BaseXmlModel, tag="InertialLocation"):
-    x: str
-    y: str
-    z: str
+    x: float
+    y: float
+    z: float
 
 
 class FileLocationType(BaseXmlModel, tag="FileLocation"):

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -2,9 +2,11 @@
 # This Source Code Form is subject to the terms of the Mozilla
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from typing import List, Any
+import enum
+
+from typing import List, Any, Set, Dict
 from pydantic import model_validator
-from pydantic_xml import BaseXmlModel, attr
+from pydantic_xml import BaseXmlModel, attr, element
 
 from .common import ParamType, IssueSeverity
 
@@ -18,10 +20,10 @@ class XMLLocationType(BaseXmlModel, tag="XMLLocation"):
     xpath: str = attr(name="xpath")
 
 
-class RoadLocationType(BaseXmlModel, tag="RoadLocation"):
-    road_id: int = attr(name="roadId")
-    t: str = attr(name="t")
-    s: str = attr(name="s")
+class InertialLocationType(BaseXmlModel, tag="InertialLocation"):
+    x: str
+    y: str
+    z: str
 
 
 class FileLocationType(BaseXmlModel, tag="FileLocation"):
@@ -33,7 +35,7 @@ class FileLocationType(BaseXmlModel, tag="FileLocation"):
 class LocationType(BaseXmlModel, tag="Location"):
     file_location: List[FileLocationType] = []
     xml_location: List[XMLLocationType] = []
-    road_location: List[RoadLocationType] = []
+    road_location: List[InertialLocationType] = []
     description: str = attr(name="description")
 
     @model_validator(mode="after")
@@ -48,18 +50,126 @@ class LocationType(BaseXmlModel, tag="Location"):
         return self
 
 
+class RuleType(BaseXmlModel, tag="AddressedRule"):
+    """
+    Type containing the Rule Schema rules and its required checks
+
+    More information at:
+        https://github.com/asam-ev/qc-framework/blob/develop/doc/manual/rule_uid_schema.md
+    """
+
+    emanating_entity: str = attr(
+        name="emanating_entity", default="", pattern=r"^((\w+(\.\w+)+))$", exclude=True
+    )
+    standard: str = attr(
+        name="standard", default="", pattern=r"^(([a-z]+))?$", exclude=True
+    )
+    definition_setting: str = attr(
+        name="definition_setting",
+        default="",
+        pattern=r"^(([0-9]+(\.[0-9]+)+))?$",
+        exclude=True,
+    )
+    rule_full_name: str = attr(
+        name="rule_full_name",
+        default="",
+        pattern=r"^((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+        exclude=True,
+    )
+
+    rule_uid: str = attr(
+        name="ruleUID",
+        default="",
+        pattern=r"^((\w+(\.\w+)+)):(([a-z]+))?:(([0-9]+(\.[0-9]+)+))?:((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+    )
+
+    @model_validator(mode="after")
+    def load_fields_into_uid(self) -> Any:
+        if (
+            self.emanating_entity != ""
+            and self.standard != ""
+            and self.definition_setting != ""
+            and self.rule_full_name != ""
+        ):
+            self.rule_uid = f"{self.emanating_entity}:{self.standard}:{self.definition_setting}:{self.rule_full_name}"
+
+        return self
+
+    @model_validator(mode="after")
+    def load_uid_into_fields(self) -> Any:
+        if self.rule_uid == "":
+            raise ValueError("Empty initialization of AddressedRule with no rule uid")
+
+        if (
+            self.emanating_entity == ""
+            and self.standard == ""
+            and self.definition_setting == ""
+            and self.rule_full_name == ""
+        ):
+            elements = self.rule_uid.split(":")
+
+            if len(elements) < 4:
+                raise ValueError(
+                    "Not enough elements to parse Rule UID. This should follow pattern described at https://github.com/asam-ev/qc-framework/blob/develop/doc/manual/rule_uid_schema.md"
+                )
+
+            self.emanating_entity = elements[0]
+            self.standard = elements[1]
+            self.definition_setting = elements[2]
+            self.rule_full_name = elements[3]
+
+        return self
+
+
 class IssueType(BaseXmlModel, tag="Issue"):
     locations: List[LocationType] = []
     issue_id: int = attr(name="issueId")
     description: str = attr(name="description")
     level: IssueSeverity = attr(name="level")
+    rule_uid: str = attr(
+        name="ruleUID",
+        default="",
+        pattern=r"^((\w+(\.\w+)+)):(([a-z]+))?:(([0-9]+(\.[0-9]+)+))?:((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+    )
 
 
-class CheckerType(BaseXmlModel, tag="Checker"):
+class MetadataType(BaseXmlModel, tag="Metadata"):
+    key: str = attr(name="key")
+    value: str = attr(name="value")
+    description: str = attr(name="description")
+
+
+class StatusType(str, enum.Enum):
+    COMPLETED = "completed"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+class CheckerType(BaseXmlModel, tag="Checker", validate_assignment=True):
+    addressed_rule: List[RuleType] = []
     issues: List[IssueType] = []
+    metadata: List[MetadataType] = []
+    status: StatusType = attr(
+        name="status", default=StatusType.SKIPPED
+    )  # = "" optional
     checker_id: str = attr(name="checkerId")
     description: str = attr(name="description")
     summary: str = attr(name="summary")
+
+    @model_validator(mode="after")
+    def check_issue_ruleUID_matches_addressed_rules(self) -> Any:
+        if len(self.issues):
+            addressed_rule_uids: Set[int] = set()
+
+            for addressed_rule in self.addressed_rule:
+                addressed_rule_uids.add(addressed_rule.rule_uid)
+
+            for issue in self.issues:
+                if issue.rule_uid not in addressed_rule_uids:
+                    raise ValueError(
+                        f"Issue Rule UID '{issue.rule_uid}' does not match addressed rules UIDs {list(addressed_rule_uids)}"
+                    )
+        return self
 
 
 class CheckerBundleType(BaseXmlModel, tag="CheckerBundle"):

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -292,6 +292,7 @@ class Result:
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
         checker.status = status
+        result.CheckerType.model_validate(checker)
 
     def get_result_version(self) -> str:
         return self._report_results.version

--- a/tests/data/demo_checker_bundle.xqar
+++ b/tests/data/demo_checker_bundle.xqar
@@ -3,7 +3,8 @@
 
   <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 1 issue" version="">
     <Checker checkerId="exampleChecker" description="This is a description" summary="">
-      <Issue description="This is an information from the demo usecase" issueId="0" level="3"/>
+      <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Issue description="This is an information from the demo usecase" issueId="0" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
     </Checker>
   </CheckerBundle>
 

--- a/tests/data/demo_checker_bundle_extended.xqar
+++ b/tests/data/demo_checker_bundle_extended.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 3 issues" version="">
+    <Checker checkerId="exampleChecker" description="This is a description" status="completed" summary="">
+      <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Issue description="This is an information from the demo usecase" issueId="0" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+    </Checker>
+    <Checker checkerId="exampleInertialChecker" description="This is a description of inertial checker" status="completed" summary="">
+      <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Issue description="This is an information from the demo usecase" issueId="1" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
+        <Locations description="inertial position">
+          <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker checkerId="exampleRuleUIDChecker" description="This is a description of ruleUID checker" status="completed" summary="">
+      <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Metadata description="Date in which the checker was executed" key="run date" value="2024/06/06"/>
+      <Metadata description="Name of the project that created the checker" key="reference project" value="project01"/>
+    </Checker>
+    <Checker checkerId="exampleIssueRuleChecker" description="This is a description of checker with issue and the involved ruleUID" status="completed" summary="">
+      <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+    </Checker>
+    <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="skipped" summary="Skipped execution"/>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <CheckerResults version="0.0.1">
   <CheckerBundle build_date="2024-05-31" description="Example checker bundle" name="TestBundle" version="0.0.1" summary="Tested example checkers">
-    <Checker checkerId="TestChecker" description="Test checker" summary="Executed evaluation">
-      <Issue issueId="0" description="Issue found at odr" level="3">
+    <Checker status="completed" checkerId="TestChecker" description="Test checker" summary="Executed evaluation">
+      <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Issue issueId="0" description="Issue found at odr" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
         <Location description="Location for issue">
           <FileLocation column="0" row="1" fileType="odr"/>
         </Location>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -201,6 +201,37 @@ def test_result_register_issue_id_generation() -> None:
     assert issue_id_0 == issue_id_1 - 1
 
 
+def test_create_issue_with_unregistered_rule_id() -> None:
+    result = Result()
+
+    result.register_checker_bundle(
+        name="TestBundle",
+        build_date="2024-05-31",
+        description="Example checker bundle",
+        version="0.0.1",
+        summary="Tested example checkers",
+    )
+
+    result.register_checker(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Test checker",
+        summary="Executed evaluation",
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=r".* Issue Rule UID 'test.com:qc:1.0.0:qwerty.qwerty' does not match addressed rules UIDs \[\].*",
+    ) as exc_info:
+        issue_id_0 = result.register_issue(
+            checker_bundle_name="TestBundle",
+            checker_id="TestChecker",
+            description="Issue found at odr",
+            level=IssueSeverity.INFORMATION,
+            rule_uid="test.com:qc:1.0.0:qwerty.qwerty",
+        )
+
+
 def test_create_rule_id_validation() -> None:
     result = Result()
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -301,3 +301,49 @@ def test_create_rule_id_validation() -> None:
             definition_setting="1.0.0",
             rule_full_name="",
         )
+
+
+def test_set_checker_status_skipped_with_issues() -> None:
+    result = Result()
+
+    result.register_checker_bundle(
+        name="TestBundle",
+        build_date="2024-05-31",
+        description="Example checker bundle",
+        version="0.0.1",
+        summary="Tested example checkers",
+    )
+
+    result.register_checker(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Test checker",
+        summary="Executed evaluation",
+    )
+
+    rule_uid = result.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        emanating_entity="test.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="qwerty.qwerty",
+    )
+
+    issue_id_0 = result.register_issue(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Issue found at odr",
+        level=IssueSeverity.INFORMATION,
+        rule_uid=rule_uid,
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=r".*\nCheckers with skipped status cannot contain issues\. .*",
+    ) as exc_info:
+        result.set_checker_status(
+            checker_bundle_name="TestBundle",
+            checker_id="TestChecker",
+            status=StatusType.SKIPPED,
+        )


### PR DESCRIPTION
**Description**

This PR addresses the Result Schema updates in order to have the Python base library in sync with the latest schema.

**Main changes**

1. Add metadata to the schema
2. Add checker status to the schema
3. Add rules definition to the schema
4. Add addressed rules to checkers
5. Add rule uid to issues
6. Update Result public interface to take into account new schema
7. Updated unit-test to include new schema

**How was the PR tested?**

1. Unit-test are passing with the updates and additions.

**Notes**
- None