### PR TITLE
Add domain specific info to result

### DIFF
--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -159,8 +159,6 @@ class DomainSpecificInfoType(
     name: str = attr(name="name")
 
 
-# Add documentation about the implementation and link issue
-# Add docs on public interface as well
 class IssueType(
     BaseXmlModel,
     tag="Issue",

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -23,9 +23,9 @@ class XMLLocationType(BaseXmlModel, tag="XMLLocation"):
 
 
 class InertialLocationType(BaseXmlModel, tag="InertialLocation"):
-    x: float
-    y: float
-    z: float
+    x: float = attr(name="x")
+    y: float = attr(name="y")
+    z: float = attr(name="z")
 
 
 class FileLocationType(BaseXmlModel, tag="FileLocation"):
@@ -34,16 +34,18 @@ class FileLocationType(BaseXmlModel, tag="FileLocation"):
     file_type: str = attr(name="fileType")
 
 
-class LocationType(BaseXmlModel, tag="Location"):
+class LocationType(BaseXmlModel, tag="Locations"):
     file_location: List[FileLocationType] = []
     xml_location: List[XMLLocationType] = []
-    road_location: List[InertialLocationType] = []
+    inertial_location: List[InertialLocationType] = []
     description: str = attr(name="description")
 
     @model_validator(mode="after")
     def check_at_least_one_element(self) -> Any:
         if (
-            len(self.file_location) + len(self.xml_location) + len(self.road_location)
+            len(self.file_location)
+            + len(self.xml_location)
+            + len(self.inertial_location)
             < 1
         ):
             raise ValueError(

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -4,9 +4,11 @@
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import enum
 
-from typing import List, Any, Set, Dict
+
+from typing import List, Any, Set
 from pydantic import model_validator
-from pydantic_xml import BaseXmlModel, attr, element
+from pydantic_xml import BaseXmlModel, attr, element, computed_element
+from lxml import etree
 
 from .common import ParamType, IssueSeverity
 
@@ -148,7 +150,18 @@ class RuleType(BaseXmlModel, tag="AddressedRule"):
         return self
 
 
-class IssueType(BaseXmlModel, tag="Issue"):
+class DomainSpecificInfoType(
+    BaseXmlModel,
+    tag="DomainSpecificInfo",
+):
+    name: str = attr(name="name")
+
+
+class IssueType(
+    BaseXmlModel,
+    tag="Issue",
+    arbitrary_types_allowed=True,
+):
     locations: List[LocationType] = []
     issue_id: int = attr(name="issueId")
     description: str = attr(name="description")
@@ -157,6 +170,9 @@ class IssueType(BaseXmlModel, tag="Issue"):
         name="ruleUID",
         default="",
         pattern=r"^((\w+(\.\w+)+)):(([a-z]+)):(([0-9]+(\.[0-9]+)+)):((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+    )
+    domain_specific_info_raw: etree._Element = element(
+        tag="DomainSpecificInfo", default=None, excluded=True
     )
 
 
@@ -176,7 +192,7 @@ class CheckerType(BaseXmlModel, tag="Checker", validate_assignment=True):
     addressed_rule: List[RuleType] = []
     issues: List[IssueType] = []
     metadata: List[MetadataType] = []
-    status: StatusType = attr(name="status", default="")
+    status: StatusType = attr(name="status", default=None)
     checker_id: str = attr(name="checkerId")
     description: str = attr(name="description")
     summary: str = attr(name="summary")

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -159,6 +159,8 @@ class DomainSpecificInfoType(
     name: str = attr(name="name")
 
 
+# Add documentation about the implementation and link issue
+# Add docs on public interface as well
 class IssueType(
     BaseXmlModel,
     tag="Issue",
@@ -173,8 +175,12 @@ class IssueType(
         default="",
         pattern=r"^((\w+(\.\w+)+)):(([a-z]+)):(([0-9]+(\.[0-9]+)+)):((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
     )
-    domain_specific_info_raw: etree._Element = element(
-        tag="DomainSpecificInfo", default=None, excluded=True
+    # Raw is defined here to enable parsing of "any" XML tag inside the domain
+    # specific information. It is linked to the DomainSpecificInfoType model
+    # to enforce the attributes.
+    # Linked Issue: https://github.com/dapper91/pydantic-xml/issues/100
+    domain_specific_info: List[etree._Element] = element(
+        tag="DomainSpecificInfo", default=[], excluded=True
     )
 
 

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -288,6 +288,29 @@ class Result:
             result.LocationType(xml_location=[xml_location], description=description)
         )
 
+    def add_inertial_location(
+        self,
+        checker_bundle_name: str,
+        checker_id: str,
+        issue_id: int,
+        x: float,
+        y: float,
+        z: float,
+        description: str,
+    ) -> None:
+        inertial_location = result.InertialLocationType(x=x, y=y, z=z)
+
+        bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
+
+        checker = self._get_checker(bundle=bundle, checker_id=checker_id)
+        issue = self._get_issue(checker=checker, issue_id=issue_id)
+
+        issue.locations.append(
+            result.LocationType(
+                inertial_location=[inertial_location], description=description
+            )
+        )
+
     def add_domain_specific_info(
         self,
         checker_bundle_name: str,

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -327,6 +327,11 @@ class Result:
         domain_specific_info_name: str,
         xml_info: List[etree._Element],
     ) -> None:
+        """
+        The XML information list provided will be wrapped in the DomainSpecificInfo
+        tag and the information will be appended to the issue list of domain
+        specific information.
+        """
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
         issue = self._get_issue(checker=checker, issue_id=issue_id)
@@ -441,6 +446,13 @@ class Result:
         checker_id: str,
         issue_id: int,
     ) -> List[DomainSpecificInfoContent]:
+        """
+        The method returns a list containing all relative DomainSpecificContent
+        dataclasses to the XML tags.
+
+        The XML information in each DomainSpecificInformation tag is unwrapped
+        and it is returned in a DomainSpecificContent dataclass.
+        """
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
         issue = self._get_issue(checker=checker, issue_id=issue_id)

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -328,9 +328,10 @@ class Result:
         xml_info: List[etree._Element],
     ) -> None:
         """
-        The XML information list provided will be wrapped in the DomainSpecificInfo
-        tag and the information will be appended to the issue list of domain
-        specific information.
+        Adds named domain specific information.
+
+        The domain specific information contains a name and a list of relevant
+        xml elements.
         """
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
@@ -447,11 +448,10 @@ class Result:
         issue_id: int,
     ) -> List[DomainSpecificInfoContent]:
         """
-        The method returns a list containing all relative DomainSpecificContent
-        dataclasses to the XML tags.
+        Returns a list of named domain specific information.
 
-        The XML information in each DomainSpecificInformation tag is unwrapped
-        and it is returned in a DomainSpecificContent dataclass.
+        Each domain specific information content contains a name and a list of
+        relevant xml elements.
         """
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -3,12 +3,20 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from copy import deepcopy
+from dataclasses import dataclass
 from typing import Union, List, Dict, Any
 from lxml import etree
 from .models import IssueSeverity, result
 
 REPORT_OUTPUT_FORMAT = "xqar"
 DEFAULT_REPORT_VERSION = "0.0.1"
+
+
+@dataclass
+class DomainSpecificInfoContent:
+    name: str
+    content: List[etree._Element]
 
 
 class IDManager:
@@ -317,17 +325,21 @@ class Result:
         checker_id: str,
         issue_id: int,
         domain_specific_info_name: str,
-        xml_info: etree._Element,
+        xml_info: List[etree._Element],
     ) -> None:
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
-
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
         issue = self._get_issue(checker=checker, issue_id=issue_id)
+
         domain_specific_tag = etree.Element(
             "DomainSpecificInfo", attrib={"name": domain_specific_info_name}
         )
-        domain_specific_tag.append(xml_info)
-        issue.domain_specific_info_raw = domain_specific_tag
+
+        for xml_info_element in xml_info:
+            xml_info_to_append = deepcopy(xml_info_element)
+            domain_specific_tag.append(xml_info_to_append)
+
+        issue.domain_specific_info.append(domain_specific_tag)
 
     def set_checker_status(
         self, checker_bundle_name: str, checker_id: str, status: result.StatusType
@@ -428,9 +440,19 @@ class Result:
         checker_bundle_name: str,
         checker_id: str,
         issue_id: int,
-    ) -> etree._Element:
+    ) -> List[DomainSpecificInfoContent]:
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
         issue = self._get_issue(checker=checker, issue_id=issue_id)
 
-        return issue.domain_specific_info_raw[0]
+        domain_specific_list = []
+
+        for domain_specific_info in issue.domain_specific_info:
+            attrib = domain_specific_info.attrib
+            info_dict = DomainSpecificInfoContent(
+                name=attrib["name"], content=domain_specific_info.getchildren()
+            )
+
+            domain_specific_list.append(info_dict)
+
+        return domain_specific_list

--- a/tests/data/demo_checker_bundle_extended.xqar
+++ b/tests/data/demo_checker_bundle_extended.xqar
@@ -25,7 +25,7 @@
         <Locations description="inertial position">
           <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
         </Locations>
-        <DomainSpecificInfo name="test_domain">
+        <DomainSpecificInfo name="test_domain_1">
           <RoadLocation b="5.4" c="0.0" id="aa" />
           <RoadLocation b="5.4" c="0.0" id="aa" />
           <TestTagFor>
@@ -35,6 +35,9 @@
               <NestedElement/>
             </InternalElementNested>
           </TestTagFor>
+        </DomainSpecificInfo>
+        <DomainSpecificInfo name="test_domain_2">
+          <RoadLocation b="5.4" c="0.0" id="aa" />
         </DomainSpecificInfo>
       </Issue>
     </Checker>

--- a/tests/data/demo_checker_bundle_extended.xqar
+++ b/tests/data/demo_checker_bundle_extended.xqar
@@ -22,6 +22,10 @@
     <Checker checkerId="exampleIssueRuleChecker" description="This is a description of checker with issue and the involved ruleUID" status="completed" summary="">
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
+
+        <Locations description="inertial position">
+          <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
+        </Locations>
         <DomainSpecificInfo name="test_domain">
           <RoadLocation b="5.4" c="0.0" id="aa" />
           <RoadLocation b="5.4" c="0.0" id="aa" />
@@ -33,6 +37,7 @@
             </InternalElementNested>
           </TestTagFor>
         </DomainSpecificInfo>
+
       </Issue>
     </Checker>
     <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="skipped" summary="Skipped execution"/>

--- a/tests/data/demo_checker_bundle_extended.xqar
+++ b/tests/data/demo_checker_bundle_extended.xqar
@@ -21,7 +21,19 @@
     </Checker>
     <Checker checkerId="exampleIssueRuleChecker" description="This is a description of checker with issue and the involved ruleUID" status="completed" summary="">
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
-      <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
+      <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
+        <DomainSpecificInfo name="test_domain">
+          <RoadLocation b="5.4" c="0.0" id="aa" />
+          <RoadLocation b="5.4" c="0.0" id="aa" />
+          <TestTagFor>
+            <InternalElementA a="1.0"/>
+            <InternalElementA a="1.0"/>
+            <InternalElementNested a="1.0">
+              <NestedElement/>
+            </InternalElementNested>
+          </TestTagFor>
+        </DomainSpecificInfo>
+      </Issue>
     </Checker>
     <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="skipped" summary="Skipped execution"/>
   </CheckerBundle>

--- a/tests/data/demo_checker_bundle_extended.xqar
+++ b/tests/data/demo_checker_bundle_extended.xqar
@@ -22,7 +22,6 @@
     <Checker checkerId="exampleIssueRuleChecker" description="This is a description of checker with issue and the involved ruleUID" status="completed" summary="">
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
-
         <Locations description="inertial position">
           <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
         </Locations>
@@ -37,7 +36,6 @@
             </InternalElementNested>
           </TestTagFor>
         </DomainSpecificInfo>
-
       </Issue>
     </Checker>
     <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="skipped" summary="Skipped execution"/>

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -4,12 +4,12 @@
     <Checker status="completed" checkerId="TestChecker" description="Test checker" summary="Executed evaluation">
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue issueId="0" description="Issue found at odr" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
-        <Location description="Location for issue">
+        <Locations description="Location for issue">
           <FileLocation column="0" row="1" fileType="odr"/>
-        </Location>
-        <Location description="Location for issue">
+        </Locations>
+        <Locations description="Location for issue">
           <XMLLocation xpath="/foo/test/path"/>
-        </Location>
+        </Locations>
       </Issue>
     </Checker>
   </CheckerBundle>

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -10,6 +10,9 @@
         <Locations description="Location for issue">
           <XMLLocation xpath="/foo/test/path"/>
         </Locations>
+        <Locations description="Location for issue">
+          <InertialLocation x="1.0" y="2.0" z="3.0"/>
+        </Locations>
       </Issue>
     </Checker>
   </CheckerBundle>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -367,6 +367,12 @@ def test_domain_specific_load(loaded_extended_result: Result):
         )
     )
 
+    # Evaluate if loading of issues with domain elements is properly done
+    assert (
+        xml_text
+        == b'<Issue issueId="2" description="This is an information from the demo usecase" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty"><Locations description="inertial position"><InertialLocation x="1.0" y="2.0" z="3.0"/></Locations><DomainSpecificInfo name="test_domain">\n          <RoadLocation b="5.4" c="0.0" id="aa"/>\n          <RoadLocation b="5.4" c="0.0" id="aa"/>\n          <TestTagFor>\n            <InternalElementA a="1.0"/>\n            <InternalElementA a="1.0"/>\n            <InternalElementNested a="1.0">\n              <NestedElement/>\n            </InternalElementNested>\n          </TestTagFor>\n        </DomainSpecificInfo>\n  \n      </Issue>\n'
+    )
+
 
 def test_domain_specific_info_add():
     result = Result()
@@ -407,12 +413,30 @@ def test_domain_specific_info_add():
     xml_info.append(etree.Element("NestedCustomTag", attrib={"test": "value"}))
     xml_info.append(etree.Element("NestedCustomTag", attrib={"test": "value"}))
 
+    result.add_xml_location(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+        xpath="/foo/test/path",
+        description="Location for issue",
+    )
+
     result.add_domain_specific_info(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",
         issue_id=issue_id,
         domain_specific_info_name="TestSpecificInfo",
         xml_info=xml_info,
+    )
+
+    result.add_file_location(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+        row=1,
+        column=0,
+        file_type="odr",
+        description="Location for issue",
     )
 
     result.write_to_file(TEST_REPORT_OUTPUT_PATH)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -358,20 +358,14 @@ def test_set_checker_status_skipped_with_issues() -> None:
 
 
 def test_domain_specific_load(loaded_extended_result: Result):
-    xml_text = (
-        loaded_extended_result._report_results.checker_bundles[0]
-        .checkers[3]
-        .issues[0]
-        .to_xml(
-            pretty_print=True,
-        )
+    issue = (
+        loaded_extended_result._report_results.checker_bundles[0].checkers[3].issues[0]
     )
 
     # Evaluate if loading of issues with domain elements is properly done
-    assert (
-        xml_text
-        == b'<Issue issueId="2" description="This is an information from the demo usecase" level="1" ruleUID="test.com:qc:1.0.0:qwerty.qwerty"><Locations description="inertial position"><InertialLocation x="1.0" y="2.0" z="3.0"/></Locations><DomainSpecificInfo name="test_domain">\n          <RoadLocation b="5.4" c="0.0" id="aa"/>\n          <RoadLocation b="5.4" c="0.0" id="aa"/>\n          <TestTagFor>\n            <InternalElementA a="1.0"/>\n            <InternalElementA a="1.0"/>\n            <InternalElementNested a="1.0">\n              <NestedElement/>\n            </InternalElementNested>\n          </TestTagFor>\n        </DomainSpecificInfo>\n  \n      </Issue>\n'
-    )
+    assert len(issue.locations) == 1
+    assert len(issue.domain_specific_info_raw) > 0
+    assert type(issue.domain_specific_info_raw) == etree._Element
 
 
 def test_domain_specific_info_add():

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from lxml import etree
 from pydantic_core import ValidationError
 from qc_baselib.models import config, result
 from qc_baselib import Result, IssueSeverity, StatusType
@@ -15,6 +16,13 @@ TEST_REPORT_OUTPUT_PATH = "tests/result_test_output.xqar"
 def loaded_result() -> Result:
     result = Result()
     result.load_from_file(DEMO_REPORT_PATH)
+    return result
+
+
+@pytest.fixture
+def loaded_extended_result() -> Result:
+    result = Result()
+    result.load_from_file(EXTENDED_DEMO_REPORT_PATH)
     return result
 
 
@@ -347,3 +355,95 @@ def test_set_checker_status_skipped_with_issues() -> None:
             checker_id="TestChecker",
             status=StatusType.SKIPPED,
         )
+
+
+def test_domain_specific_load(loaded_extended_result: Result):
+    xml_text = (
+        loaded_extended_result._report_results.checker_bundles[0]
+        .checkers[3]
+        .issues[0]
+        .to_xml(
+            pretty_print=True,
+        )
+    )
+
+
+def test_domain_specific_info_add():
+    result = Result()
+
+    result.register_checker_bundle(
+        name="TestBundle",
+        build_date="2024-05-31",
+        description="Example checker bundle",
+        version="0.0.1",
+        summary="Tested example checkers",
+    )
+
+    result.register_checker(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Test checker",
+        summary="Executed evaluation",
+    )
+
+    rule_uid = result.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        emanating_entity="test.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="qwerty.qwerty",
+    )
+
+    issue_id = result.register_issue(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Issue found at odr",
+        level=IssueSeverity.INFORMATION,
+        rule_uid=rule_uid,
+    )
+
+    xml_info = etree.Element("TestCustomTag", attrib={"test": "value"})
+    xml_info.append(etree.Element("NestedCustomTag", attrib={"test": "value"}))
+    xml_info.append(etree.Element("NestedCustomTag", attrib={"test": "value"}))
+
+    result.add_domain_specific_info(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+        domain_specific_info_name="TestSpecificInfo",
+        xml_info=xml_info,
+    )
+
+    result.write_to_file(TEST_REPORT_OUTPUT_PATH)
+
+    output_result = Result()
+    output_result.load_from_file(TEST_REPORT_OUTPUT_PATH)
+
+    domain_specific_xml_element = output_result.get_domain_specific_info(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+    )
+
+    domain_specific_xml_text = (
+        etree.tostring(
+            domain_specific_xml_element,
+        )
+        .decode("utf-8")
+        .replace(" ", "")
+        .replace("\n", "")
+    )  # need to take out any whitespace or \n due to tree indentation
+
+    xml_info_text = (
+        etree.tostring(
+            xml_info,
+        )
+        .decode("utf-8")
+        .replace(" ", "")
+        .replace("\n", "")
+    )  # need to take out any whitespace or \n due to tree indentation
+
+    assert domain_specific_xml_text == xml_info_text
+
+    os.remove(TEST_REPORT_OUTPUT_PATH)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -89,6 +89,15 @@ def test_result_write() -> None:
         xpath="/foo/test/path",
         description="Location for issue",
     )
+    result.add_inertial_location(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+        x=1.0,
+        y=2.0,
+        z=3.0,
+        description="Location for issue",
+    )
 
     result.set_checker_status(
         checker_bundle_name="TestBundle",


### PR DESCRIPTION
**Description**

This PR adds the `DomainSpecificInfo` to the `IssueType`.

It also fixes some missing details from the previous schema update in the lib.

**Main changes**

1. Add `DomainSpecificInfo` to the `IssueType`
2. Add missing location elements methods for Results
3. Extend tests to check all added and updated cases

**How was the PR tested?**

1. Unit-test are passing as intended after updates.

**Notes**
- None.