### PR TITLE
Add get issues by rule uid to Result

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -468,3 +468,14 @@ class Result:
             domain_specific_list.append(info_dict)
 
         return domain_specific_list
+
+    def get_issues_by_rule_id(self, rule_uid: str) -> List[result.IssueType]:
+        rule_issues: List[result.IssueType] = []
+
+        for bundle in self._report_results.checker_bundles:
+            for checker in bundle.checkers:
+                for issue in checker.issues:
+                    if issue.rule_uid == rule_uid:
+                        rule_issues.append(issue)
+
+        return rule_issues

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -494,3 +494,83 @@ def test_domain_specific_info_add():
     assert domain_specific_xml_text == xml_info_text
 
     os.remove(TEST_REPORT_OUTPUT_PATH)
+
+
+def test_get_issue_by_rule_uid() -> None:
+    result_report = Result()
+
+    result_report.register_checker_bundle(
+        name="TestBundle",
+        build_date="2024-05-31",
+        description="Example checker bundle",
+        version="0.0.1",
+        summary="Tested example checkers",
+    )
+
+    result_report.register_checker(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Test checker",
+        summary="Executed evaluation",
+    )
+
+    rule_uid_1 = result_report.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        emanating_entity="test.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="qwerty.qwerty",
+    )
+
+    issue_id = result_report.register_issue(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Issue found at odr",
+        level=IssueSeverity.INFORMATION,
+        rule_uid=rule_uid_1,
+    )
+
+    issue_id = result_report.register_issue(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Issue found at odr secondary",
+        level=IssueSeverity.INFORMATION,
+        rule_uid=rule_uid_1,
+    )
+
+    result_report.register_checker(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker2",
+        description="Test checker 2",
+        summary="Executed evaluation 2",
+    )
+
+    rule_uid_2 = result_report.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker2",
+        emanating_entity="new.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="qwerty.qwerty",
+    )
+
+    issue_id = result_report.register_issue(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker2",
+        description=f"Issue found at odr on rule uid {rule_uid_2}",
+        level=IssueSeverity.INFORMATION,
+        rule_uid=rule_uid_2,
+    )
+
+    rule_uid_1_issues = result_report.get_issues_by_rule_id(rule_uid_1)
+    rule_uid_2_issues = result_report.get_issues_by_rule_id(rule_uid_2)
+
+    assert len(rule_uid_1_issues) == 2
+    assert len(rule_uid_2_issues) == 1
+    assert type(rule_uid_2_issues[0]) == result.IssueType
+    assert (
+        rule_uid_2_issues[0].description
+        == f"Issue found at odr on rule uid {rule_uid_2}"
+    )
+    assert rule_uid_2_issues[0].level == IssueSeverity.INFORMATION


### PR DESCRIPTION
**Description**

This PR adds a method to retrieve all issues identified by a given rule uid.

**Main changes**

1. [Add get_issues_by_rule_uid implementation to Result](https://github.com/asam-ev/qc-baselib-py/commit/96d1a037e97e6b796ecd0f26407fa99c5c675375)
2. [Add test to new added method](https://github.com/asam-ev/qc-baselib-py/commit/55d14d2fa5e390a58e0856dc8df5082ed52b8287)

**How was the PR tested?**

1. Unit-test added to test the functionality of the new method.

**Notes**
- None