### PR TITLE
Fix typo on get issues method

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -469,7 +469,7 @@ class Result:
 
         return domain_specific_list
 
-    def get_issues_by_rule_id(self, rule_uid: str) -> List[result.IssueType]:
+    def get_issues_by_rule_uid(self, rule_uid: str) -> List[result.IssueType]:
         rule_issues: List[result.IssueType] = []
 
         for bundle in self._report_results.checker_bundles:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -563,8 +563,8 @@ def test_get_issue_by_rule_uid() -> None:
         rule_uid=rule_uid_2,
     )
 
-    rule_uid_1_issues = result_report.get_issues_by_rule_id(rule_uid_1)
-    rule_uid_2_issues = result_report.get_issues_by_rule_id(rule_uid_2)
+    rule_uid_1_issues = result_report.get_issues_by_rule_uid(rule_uid_1)
+    rule_uid_2_issues = result_report.get_issues_by_rule_uid(rule_uid_2)
 
     assert len(rule_uid_1_issues) == 2
     assert len(rule_uid_2_issues) == 1


### PR DESCRIPTION
**Description**

This PR fixes a typo on the `get_issues_by_rule_uid` which was `get_issues_by_rule_id` previously.

**Main changes**

1. Fix typo on get issues by rule uid method
2. Fix tests using the new method

**How was the PR tested?**

1. Unit-test are passing with the changes.

**Notes**
- None