### PR TITLE
Remove file type from result file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ def main():
         issue_id=issue_id,
         row=1,
         column=0,
-        file_type="odr",
         description="Location for issue",
     )
 

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -31,7 +31,6 @@ class InertialLocationType(BaseXmlModel):
 class FileLocationType(BaseXmlModel):
     column: int = attr(name="column")
     row: int = attr(name="row")
-    file_type: str = attr(name="fileType")
 
 
 class LocationType(BaseXmlModel):

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -259,13 +259,11 @@ class Result:
         issue_id: int,
         row: int,
         column: int,
-        file_type: str,
         description: str,
     ) -> None:
         file_location = result.FileLocationType(
             row=row,
             column=column,
-            file_type=file_type,
         )
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -5,7 +5,7 @@
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue issueId="0" description="Issue found at odr" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
         <Locations description="Location for issue">
-          <FileLocation column="0" row="1" fileType="odr"/>
+          <FileLocation column="0" row="1"/>
         </Locations>
         <Locations description="Location for issue">
           <XMLLocation xpath="/foo/test/path"/>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -79,7 +79,6 @@ def test_result_write() -> None:
         issue_id=issue_id,
         row=1,
         column=0,
-        file_type="odr",
         description="Location for issue",
     )
     result.add_xml_location(
@@ -439,7 +438,6 @@ def test_domain_specific_info_add():
         issue_id=issue_id,
         row=1,
         column=0,
-        file_type="odr",
         description="Location for issue",
     )
 


### PR DESCRIPTION
**Description**

This PR removes a field that was considered unnecessary for file type, since the framework is meant to be file/standard agnostic.

**Main changes**

1. [Remove file type on models](https://github.com/asam-ev/qc-baselib-py/commit/942b7cae8f2a8904f5525ed740a6f942124160f1) 
2. [Remove file type from Result interface](https://github.com/asam-ev/qc-baselib-py/commit/7f02f9ec844a22c421bc87e89ff81e27165c21ca) 
3. [Update tests with field removal](https://github.com/asam-ev/qc-baselib-py/commit/64c52e3751ed27990c85112a9b9ee124e80d756b) 
4. [Remove file type from README example](https://github.com/asam-ev/qc-baselib-py/commit/395289d5c33d7681de3a698c1bf943506855f71b) 

**How was the PR tested?**

1. Unit-test are working with the updates.

**Notes**
- Related to https://github.com/asam-ev/qc-framework/issues/99