### PR TITLE
Add support for multiple xpath on Result add_xml_location

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -280,10 +280,16 @@ class Result:
         checker_bundle_name: str,
         checker_id: str,
         issue_id: int,
-        xpath: str,
+        xpath: Union[str, List[str]],
         description: str,
     ) -> None:
-        xml_location = result.XMLLocationType(xpath=xpath)
+        xml_locations = []
+
+        if type(xpath) == str:
+            xml_locations.append(result.XMLLocationType(xpath=xpath))
+        elif type(xpath) == list:
+            for path in xpath:
+                xml_locations.append(result.XMLLocationType(xpath=path))
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
 
@@ -291,7 +297,7 @@ class Result:
         issue = self._get_issue(checker=checker, issue_id=issue_id)
 
         issue.locations.append(
-            result.LocationType(xml_location=[xml_location], description=description)
+            result.LocationType(xml_location=xml_locations, description=description)
         )
 
     def add_inertial_location(

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -10,6 +10,10 @@
         <Locations description="Location for issue">
           <XMLLocation xpath="/foo/test/path"/>
         </Locations>
+        <Locations description="Location for issue with list">
+          <XMLLocation xpath="/foo/test/path"/>
+          <XMLLocation xpath="/bar/test/path"/>
+        </Locations>
         <Locations description="Location for issue">
           <InertialLocation x="1.0" y="2.0" z="3.0"/>
         </Locations>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -88,6 +88,13 @@ def test_result_write() -> None:
         xpath="/foo/test/path",
         description="Location for issue",
     )
+    result.add_xml_location(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+        xpath=["/foo/test/path", "/bar/test/path"],
+        description="Location for issue with list",
+    )
     result.add_inertial_location(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",


### PR DESCRIPTION
**Description**

This PR adds the option to pass a list of `xpath` locations for creating a XML Location using the `add_xml_location` method on the Result interface.

**Main changes**

1. [Add support to list xpath location on add_xml_location](https://github.com/asam-ev/qc-baselib-py/commit/ded906f9c236d236c27bf471b9ca7bddaf45fda2) 
2. [Update tests with new supported option](https://github.com/asam-ev/qc-baselib-py/commit/4a12af3f0c34dea3f275e736eb2c68f91ea39885)First change

**How was the PR tested?**

1. Unit-test are passing with the updates.

**Notes**
