### PR TITLE
Remove file type from result format and add a minor improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ def main():
         issue_id=issue_id,
         row=1,
         column=0,
-        file_type="odr",
         description="Location for issue",
     )
 

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -31,7 +31,6 @@ class InertialLocationType(BaseXmlModel):
 class FileLocationType(BaseXmlModel):
     column: int = attr(name="column")
     row: int = attr(name="row")
-    file_type: str = attr(name="fileType")
 
 
 class LocationType(BaseXmlModel):

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -259,13 +259,11 @@ class Result:
         issue_id: int,
         row: int,
         column: int,
-        file_type: str,
         description: str,
     ) -> None:
         file_location = result.FileLocationType(
             row=row,
             column=column,
-            file_type=file_type,
         )
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -280,10 +280,16 @@ class Result:
         checker_bundle_name: str,
         checker_id: str,
         issue_id: int,
-        xpath: str,
+        xpath: Union[str, List[str]],
         description: str,
     ) -> None:
-        xml_location = result.XMLLocationType(xpath=xpath)
+        xml_locations = []
+
+        if type(xpath) == str:
+            xml_locations.append(result.XMLLocationType(xpath=xpath))
+        elif type(xpath) == list:
+            for path in xpath:
+                xml_locations.append(result.XMLLocationType(xpath=path))
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
 
@@ -291,7 +297,7 @@ class Result:
         issue = self._get_issue(checker=checker, issue_id=issue_id)
 
         issue.locations.append(
-            result.LocationType(xml_location=[xml_location], description=description)
+            result.LocationType(xml_location=xml_locations, description=description)
         )
 
     def add_inertial_location(

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -10,6 +10,10 @@
         <Locations description="Location for issue">
           <XMLLocation xpath="/foo/test/path"/>
         </Locations>
+        <Locations description="Location for issue with list">
+          <XMLLocation xpath="/foo/test/path"/>
+          <XMLLocation xpath="/bar/test/path"/>
+        </Locations>
         <Locations description="Location for issue">
           <InertialLocation x="1.0" y="2.0" z="3.0"/>
         </Locations>

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -5,7 +5,7 @@
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue issueId="0" description="Issue found at odr" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
         <Locations description="Location for issue">
-          <FileLocation column="0" row="1" fileType="odr"/>
+          <FileLocation column="0" row="1"/>
         </Locations>
         <Locations description="Location for issue">
           <XMLLocation xpath="/foo/test/path"/>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -88,6 +88,13 @@ def test_result_write() -> None:
         xpath="/foo/test/path",
         description="Location for issue",
     )
+    result.add_xml_location(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        issue_id=issue_id,
+        xpath=["/foo/test/path", "/bar/test/path"],
+        description="Location for issue with list",
+    )
     result.add_inertial_location(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -79,7 +79,6 @@ def test_result_write() -> None:
         issue_id=issue_id,
         row=1,
         column=0,
-        file_type="odr",
         description="Location for issue",
     )
     result.add_xml_location(
@@ -439,7 +438,6 @@ def test_domain_specific_info_add():
         issue_id=issue_id,
         row=1,
         column=0,
-        file_type="odr",
         description="Location for issue",
     )
 


### PR DESCRIPTION
**Description**

This PR removes the file type from the result format and supports for adding multiple XPath on Result.add_xml_location method.

**Main changes**

1. #14 
2. #15 

**How was the PR tested?**

1. Tests are documented in each individual PR.

**Notes**

Close https://github.com/asam-ev/qc-framework/issues/99.
