### PR TITLE
Add json validator example

### DIFF
--- a/examples/json_validator/README.md
+++ b/examples/json_validator/README.md
@@ -1,0 +1,59 @@
+# qc-json
+
+This project implements a test JSON checker for the ASAM Quality Checker project.
+
+
+## Installation
+
+To install the project, run:
+
+```
+pip install -r requirements.txt
+```
+
+This will install the needed dependencies to your local Python.
+
+## Usage
+
+The checker can be used as a Python script:
+
+```
+python json_validator.py --help
+
+usage: QC JSON Checker [-h] (-c CONFIG_PATH)
+
+This is a collection of scripts for checking validity of OpenDrive (.xodr) files.
+
+options:
+  -h, --help            show this help message and exit
+  -c CONFIG_PATH, --config_path CONFIG_PATH
+
+```
+
+### Example
+
+- No issues found
+
+```
+$ python python json_validator.py \
+    -c config/valid.xml
+2024-08-05 10:38:07,978 - Initializing checks
+2024-08-05 10:38:07,979 - JsonFile = data/valid.json
+2024-08-05 10:38:07,979 - resultFile = json_bundle_report.xqar
+2024-08-05 10:38:07,979 - Issues found - 0
+2024-08-05 10:38:07,979 - Report file written to json_bundle_report.xqar
+2024-08-05 10:38:07,979 - Done
+```
+
+- Issues found on file
+
+```
+$ python python json_validator.py \
+    -c config/invalid.xml
+2024-08-05 10:38:11,946 - Initializing checks
+2024-08-05 10:38:11,946 - JsonFile = data/invalid.json
+2024-08-05 10:38:11,946 - resultFile = json_bundle_report.xqar
+2024-08-05 10:38:11,947 - Issues found - 1
+2024-08-05 10:38:11,947 - Report file written to json_bundle_report.xqar
+2024-08-05 10:38:11,947 - Done
+```

--- a/examples/json_validator/config/invalid.xml
+++ b/examples/json_validator/config/invalid.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Config>
+
+    <Param name="JsonFile" value="data/invalid.json" />
+
+    <CheckerBundle application="jsonBundle">
+        <Param name="resultFile" value="json_bundle_report.xqar" />
+        <Checker checkerId="jsonChecker" maxLevel="1" minLevel="3" />
+    </CheckerBundle>
+
+    <ReportModule application="TextReport">
+        <Param name="strInputFile" value="Result.xqar" />
+        <Param name="strReportFile" value="Report.txt" />
+    </ReportModule>
+
+</Config>

--- a/examples/json_validator/config/valid.xml
+++ b/examples/json_validator/config/valid.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Config>
+
+    <Param name="JsonFile" value="data/valid.json" />
+
+    <CheckerBundle application="jsonBundle">
+        <Param name="resultFile" value="json_bundle_report.xqar" />
+        <Checker checkerId="jsonChecker" maxLevel="1" minLevel="3" />
+    </CheckerBundle>
+
+
+    <ReportModule application="TextReport">
+        <Param name="strInputFile" value="Result.xqar" />
+        <Param name="strReportFile" value="Report.txt" />
+    </ReportModule>
+
+</Config>

--- a/examples/json_validator/data/invalid.json
+++ b/examples/json_validator/data/invalid.json
@@ -1,0 +1,6 @@
+{
+    "product_id": ,
+    "product_name": "Laptop",
+    "price": "0",
+    "present": true
+}

--- a/examples/json_validator/data/valid.json
+++ b/examples/json_validator/data/valid.json
@@ -1,0 +1,6 @@
+{
+    "product_id": "12345",
+    "name": "Laptop",
+    "price": 999.99,
+    "in_stock": true
+}

--- a/examples/json_validator/json_validator.py
+++ b/examples/json_validator/json_validator.py
@@ -1,0 +1,106 @@
+import os
+import argparse
+import logging
+from datetime import datetime
+import json
+
+from qc_baselib import Configuration, Result, IssueSeverity, StatusType
+
+BUNDLE_NAME = "jsonBundle"
+BUNDLE_VERSION = "1.0.0"
+CHECKER_ID = "jsonChecker"
+
+
+logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
+
+
+def is_valid_json(file_path):
+    try:
+        with open(file_path, "r") as file:
+            json.load(file)
+        return True
+    except (json.JSONDecodeError, FileNotFoundError, IOError):
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="QC JSON Checker",
+        description="This is a collection of scripts for checking validity of JSON (.json) files.",
+    )
+
+    parser.add_argument("-c", "--config_path")
+    args = parser.parse_args()
+    logging.info("Initializing checks")
+
+    # Create config object
+    config = Configuration()
+    config.load_from_file(xml_file_path=args.config_path)
+
+    # Create result object
+    result = Result()
+
+    json_file = config.get_config_param("JsonFile")
+    result_file = config.get_checker_bundle_param("jsonBundle", "resultFile")
+
+    logging.info(f"JsonFile = {json_file}")
+    logging.info(f"resultFile = {result_file}")
+
+    # 1. Register checker bundle
+    result.register_checker_bundle(
+        name=BUNDLE_NAME,
+        build_date=datetime.today().strftime("%Y-%m-%d"),
+        description="JSON checker bundle",
+        version=BUNDLE_VERSION,
+        summary="",
+    )
+    result.set_result_version(version=BUNDLE_VERSION)
+
+    # 2. Register checker
+    result.register_checker(
+        checker_bundle_name=BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        description="Json validation checker",
+        summary="",
+    )
+
+    # Register addressed rule
+    rule_uid = result.register_rule(
+        checker_bundle_name=BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        emanating_entity="asam.net",
+        standard="json",
+        definition_setting="1.0.0",
+        rule_full_name="valid_schema",
+    )
+
+    # Execute the check logic
+    is_valid = is_valid_json(json_file)
+
+    if not is_valid:
+        issue_id = result.register_issue(
+            checker_bundle_name=BUNDLE_NAME,
+            checker_id=CHECKER_ID,
+            description="Issue flagging when input file contains no valid json info",
+            level=IssueSeverity.ERROR,
+            rule_uid=rule_uid,
+        )
+
+    logging.info(
+        f"Issues found - {result.get_checker_issue_count(checker_bundle_name=BUNDLE_NAME, checker_id=CHECKER_ID)}"
+    )
+    result.set_checker_status(
+        checker_bundle_name=BUNDLE_NAME,
+        checker_id=CHECKER_ID,
+        status=StatusType.COMPLETED,
+    )
+
+    # 4. Write result file
+    result.write_to_file(result_file)
+
+    logging.info(f"Report file written to {result_file}")
+    logging.info(f"Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/json_validator/requirements.txt
+++ b/examples/json_validator/requirements.txt
@@ -1,0 +1,1 @@
+qc_baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop


### PR DESCRIPTION
**Description**

Add example to show how to use base library for a custom checker bundle. In particular the example shows a json validation executed with base library configuration and result objects usage

**How was the PR tested?**

1. Unit-test with  sample data. All unit tests passed.

**Notes**

Example execution

```
python json_validator.py \
    -c config/invalid.xml
2024-08-05 10:38:11,946 - Initializing checks
2024-08-05 10:38:11,946 - JsonFile = data/invalid.json
2024-08-05 10:38:11,946 - resultFile = json_bundle_report.xqar
2024-08-05 10:38:11,947 - Issues found - 1
2024-08-05 10:38:11,947 - Report file written to json_bundle_report.xqar
2024-08-05 10:38:11,947 - Done
```