### PR TITLE
Fix models search mode to catch all sub-elements occurrences 

### DIFF
--- a/qc_baselib/models/config.py
+++ b/qc_baselib/models/config.py
@@ -26,7 +26,7 @@ class ReportModuleType(BaseXmlModel):
     application: str = attr(name="application")
 
 
-class CheckerBundleType(BaseXmlModel, search_mode="ordered"):
+class CheckerBundleType(BaseXmlModel, search_mode="unordered"):
     params: List[ParamType] = element(tag="Param", default=[])
     checkers: List[CheckerType] = element(tag="Checker", default=[])
     application: str = attr(name="application")
@@ -40,7 +40,7 @@ class CheckerBundleType(BaseXmlModel, search_mode="ordered"):
         return self
 
 
-class Config(BaseXmlModel, tag="Config", search_mode="ordered"):
+class Config(BaseXmlModel, tag="Config", search_mode="unordered"):
     params: List[ParamType] = element(tag="Param", default=[])
     reports: List[ReportModuleType] = element(tag="ReportModule", default=[])
     checker_bundles: List[CheckerBundleType] = element(tag="CheckerBundle", default=[])

--- a/qc_baselib/models/config.py
+++ b/qc_baselib/models/config.py
@@ -40,7 +40,7 @@ class CheckerBundleType(BaseXmlModel):
         return self
 
 
-class Config(BaseXmlModel, tag="Config"):
+class Config(BaseXmlModel, tag="Config", search_mode="ordered"):
     params: List[ParamType] = element(tag="Param", default=[])
     reports: List[ReportModuleType] = element(tag="ReportModule", default=[])
     checker_bundles: List[CheckerBundleType] = element(tag="CheckerBundle", default=[])

--- a/qc_baselib/models/config.py
+++ b/qc_baselib/models/config.py
@@ -26,7 +26,7 @@ class ReportModuleType(BaseXmlModel):
     application: str = attr(name="application")
 
 
-class CheckerBundleType(BaseXmlModel):
+class CheckerBundleType(BaseXmlModel, search_mode="ordered"):
     params: List[ParamType] = element(tag="Param", default=[])
     checkers: List[CheckerType] = element(tag="Checker", default=[])
     application: str = attr(name="application")

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -33,7 +33,7 @@ class FileLocationType(BaseXmlModel):
     row: int = attr(name="row")
 
 
-class LocationType(BaseXmlModel, search_mode="ordered"):
+class LocationType(BaseXmlModel, search_mode="unordered"):
     file_location: List[FileLocationType] = element(tag="FileLocation", default=[])
     xml_location: List[XMLLocationType] = element(tag="XMLLocation", default=[])
     inertial_location: List[InertialLocationType] = element(
@@ -194,7 +194,7 @@ class StatusType(str, enum.Enum):
     SKIPPED = "skipped"
 
 
-class CheckerType(BaseXmlModel, validate_assignment=True, search_mode="ordered"):
+class CheckerType(BaseXmlModel, validate_assignment=True, search_mode="unordered"):
     addressed_rule: List[RuleType] = element(tag="AddressedRule", default=[])
     issues: List[IssueType] = element(tag="Issue", default=[])
     metadata: List[MetadataType] = element(tag="Metadata", default=[])
@@ -227,7 +227,7 @@ class CheckerType(BaseXmlModel, validate_assignment=True, search_mode="ordered")
         return self
 
 
-class CheckerBundleType(BaseXmlModel, search_mode="ordered"):
+class CheckerBundleType(BaseXmlModel, search_mode="unordered"):
     params: List[ParamType] = element(tag="Param", default=[])
     checkers: List[CheckerType] = element(tag="Checker", default=[])
     build_date: str = attr(name="build_date")

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -33,7 +33,7 @@ class FileLocationType(BaseXmlModel):
     row: int = attr(name="row")
 
 
-class LocationType(BaseXmlModel):
+class LocationType(BaseXmlModel, search_mode="ordered"):
     file_location: List[FileLocationType] = element(tag="FileLocation", default=[])
     xml_location: List[XMLLocationType] = element(tag="XMLLocation", default=[])
     inertial_location: List[InertialLocationType] = element(
@@ -44,7 +44,9 @@ class LocationType(BaseXmlModel):
     @model_validator(mode="after")
     def check_at_least_one_element(self) -> Any:
         if (
-            len(self.file_location) + len(self.xml_location) + len(self.inertial_location)
+            len(self.file_location)
+            + len(self.xml_location)
+            + len(self.inertial_location)
             < 1
         ):
             raise ValueError(
@@ -225,7 +227,7 @@ class CheckerType(BaseXmlModel, validate_assignment=True, search_mode="ordered")
         return self
 
 
-class CheckerBundleType(BaseXmlModel):
+class CheckerBundleType(BaseXmlModel, search_mode="ordered"):
     params: List[ParamType] = element(tag="Param", default=[])
     checkers: List[CheckerType] = element(tag="Checker", default=[])
     build_date: str = attr(name="build_date")

--- a/tests/data/ordered_config.xml
+++ b/tests/data/ordered_config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Config>
+
+  <Param name="InputFile" value="../stimuli/xodr_examples/three_connected_roads_with_steps.xodr" />
+
+  <ReportModule application="TextReport">
+    <Param name="strInputFile" value="Result.xqar" />
+    <Param name="strReportFile" value="Report.txt" />
+  </ReportModule>
+
+  <CheckerBundle application="DemoCheckerBundle">
+    <Param name="strResultFile" value="DemoCheckerBundle.xqar" />
+    <Checker checkerId="exampleChecker" maxLevel="1" minLevel="3" />
+  </CheckerBundle>
+
+
+
+</Config>

--- a/tests/data/unordered_config.xml
+++ b/tests/data/unordered_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Config>
+
+  <Param name="InputFile" value="../stimuli/xodr_examples/three_connected_roads_with_steps.xodr" />
+
+  <CheckerBundle application="DemoCheckerBundle">
+    <Param name="strResultFile" value="DemoCheckerBundle.xqar" />
+    <Checker checkerId="exampleChecker" maxLevel="1" minLevel="3" />
+  </CheckerBundle>
+
+  <ReportModule application="TextReport">
+    <Param name="strInputFile" value="Result.xqar" />
+    <Param name="strReportFile" value="Report.txt" />
+  </ReportModule>
+
+</Config>

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -8,7 +8,7 @@ import pytest
 from qc_baselib.models import config, result
 from qc_baselib import Configuration
 
-
+TEST_DATA_BASE_PATH = "tests/data"
 DEMO_CONFIG_PATH = "tests/data/demo_checker_bundle_config.xml"
 EXAMPLE_OUTPUT_CONFIG_PATH = "tests/data/config_test_output.xml"
 TEST_CONFIG_OUTPUT_PATH = "tests/config_test_output.xml"
@@ -172,3 +172,27 @@ def test_config_write() -> None:
     assert output_xml_text == example_xml_text
 
     os.remove(TEST_CONFIG_OUTPUT_PATH)
+
+
+def test_config_file_parse_order_independency() -> None:
+    config_unordered = Configuration()
+    config_unordered.load_from_file(
+        os.path.join(TEST_DATA_BASE_PATH, "unordered_config.xml")
+    )
+
+    config_ordered = Configuration()
+    config_ordered.load_from_file(
+        os.path.join(TEST_DATA_BASE_PATH, "ordered_config.xml")
+    )
+
+    assert len(config_ordered._configuration.reports) == len(
+        config_unordered._configuration.reports
+    )
+
+    assert len(config_ordered._configuration.checker_bundles) == len(
+        config_unordered._configuration.checker_bundles
+    )
+
+    assert len(config_ordered._configuration.params) == len(
+        config_unordered._configuration.params
+    )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -174,7 +174,7 @@ def test_config_write() -> None:
     os.remove(TEST_CONFIG_OUTPUT_PATH)
 
 
-def test_config_file_parse_order_independency() -> None:
+def test_config_file_parse_order_independence() -> None:
     config_unordered = Configuration()
     config_unordered.load_from_file(
         os.path.join(TEST_DATA_BASE_PATH, "unordered_config.xml")


### PR DESCRIPTION
**Description**

This PR adds a fix for an issue where the models where parsing wrongly the XML files because they were expecting a given order for the elements. With this new implementation the order does not matter anymore and all elements will be parsed.

**Main changes**

1. Add search mode unordered to elements with more than one sub-element
2. Add tests for the order independence of the models

**How was the PR tested?**

1. Unit-test with some sample data for order difference.

**Notes**
- None.