### PR TITLE
Add get all methods for checker bundles and report modules

### DIFF
--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from typing import Union
+from typing import Union, List
 from .models import config, common, IssueSeverity
 
 
@@ -88,6 +88,12 @@ class Configuration:
         )
 
         return bundle
+
+    def get_all_checker_bundles(self) -> List[config.CheckerBundleType]:
+        return self._configuration.checker_bundles
+
+    def get_all_report_modules(self) -> List[config.ReportModuleType]:
+        return self._configuration.reports
 
     def get_config_param(self, param_name: str) -> Union[str, int, float, None]:
         if len(self._configuration.params) == 0:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -196,3 +196,13 @@ def test_config_file_parse_order_independence() -> None:
     assert len(config_ordered._configuration.params) == len(
         config_unordered._configuration.params
     )
+
+
+def test_get_all_methods() -> None:
+    config = Configuration()
+    config.load_from_file(os.path.join(TEST_DATA_BASE_PATH, "unordered_config.xml"))
+
+    assert len(config._configuration.reports) == len(config.get_all_report_modules())
+    assert len(config._configuration.checker_bundles) == len(
+        config.get_all_checker_bundles()
+    )


### PR DESCRIPTION
**Description**

This PR adds some helper functions to return all checkers bundles and report modules registered in a configuration.

**Main changes**

1. Add get all methods
2. Add tests for new functions

**How was the PR tested?**

1. Unit-test with new functions test cases.

**Notes**
- None.