### PR TITLE
Remove requirements.txt as we use pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-annotated-types>=0.7.0 ; python_version >= "3.10" and python_version < "4.0"
-lxml>=5.3.0 ; python_version >= "3.10" and python_version < "4.0"
-pydantic-core>=2.20.1 ; python_version >= "3.10" and python_version < "4.0"
-pydantic-xml>=2.11.0 ; python_version >= "3.10" and python_version < "4.0"
-pydantic>=2.8.2 ; python_version >= "3.10" and python_version < "4.0"
-typing-extensions>=4.12.2 ; python_version >= "3.10" and python_version < "4.0"


### PR DESCRIPTION
**Description**

Keeping requirements.txt makes the dependency information duplicated. It also creates confusing behavior when users install this package via pip, as it's not clear what transitive dependencies will be installed.

Now, dependencies can only be specified in `pyproject.toml`.

Example issue caused by `requirements.txt`: https://github.com/asam-ev/qc-openscenarioxml/actions/runs/10496425116/job/29077033846

**Main changes**

1. Removed requirements.txt.

**How was the PR tested?**

1. Unit-test and testing via qc-openscenarioxml import.

**Notes**
