### PR TITLE
Add a warning message when multiple rules are registered to a check

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Union, List, Set
 from lxml import etree
 from .models import IssueSeverity, result
+import logging
 
 REPORT_OUTPUT_FORMAT = "xqar"
 DEFAULT_REPORT_VERSION = "0.0.1"
@@ -280,6 +281,16 @@ class Result:
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
         checker.addressed_rule.append(rule)
+
+        number_of_addressed_rules = len(checker.addressed_rule)
+        if number_of_addressed_rules > 1:
+            logging.warning(
+                f"There are {number_of_addressed_rules} rules registered to the check"
+                f" {checker_id}. A check should address exactly one rule, unless there"
+                " is a strong reason not to. See the following document for more"
+                " information:"
+                " https://github.com/asam-ev/qc-framework/blob/main/doc/manual/checker_library.md#check-characteristics"
+            )
 
         return rule.rule_uid
 


### PR DESCRIPTION
**Description**

Add a warning when multiple rules are registered to a check.

See also 

**Main changes**

1. First change
2. Second change

**How was the PR tested?**

1. Tested via qc_opendrive and see that the warning is printed out correctly.

**Notes**
Related issue: 
* https://github.com/asam-ev/qc-framework/issues/163