### PR TITLE
Make summary as optional when register checkers and checker bundles

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -46,7 +46,6 @@ class Result:
         build_date="2024-05-31",
         description="Example checker bundle",
         version="0.0.1",
-        summary="Tested example checkers",
     )
 
     result.write_to_file("testResults.xqar")
@@ -225,7 +224,12 @@ class Result:
         return issue
 
     def register_checker_bundle(
-        self, build_date: str, description: str, name: str, version: str, summary: str
+        self,
+        build_date: str,
+        description: str,
+        name: str,
+        version: str,
+        summary: str = "",
     ) -> None:
         bundle = result.CheckerBundleType(
             build_date=build_date,
@@ -245,7 +249,7 @@ class Result:
         checker_bundle_name: str,
         checker_id: str,
         description: str,
-        summary: str,
+        summary: str = "",
     ) -> None:
 
         checker = result.CheckerType(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -728,3 +728,22 @@ def test_has_at_least_one_issue_from_rules() -> None:
     )
 
     assert result_report.has_at_least_one_issue_from_rules({}) == False
+
+
+def test_has_at_least_one_issue_from_rules() -> None:
+    result_report = Result()
+
+    result_report.register_checker_bundle(
+        name="TestBundle",
+        build_date="2024-05-31",
+        description="Example checker bundle",
+        version="0.0.1",
+    )
+
+    result_report.register_checker(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        description="Test checker",
+    )
+
+    assert True

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -730,7 +730,7 @@ def test_has_at_least_one_issue_from_rules() -> None:
     assert result_report.has_at_least_one_issue_from_rules({}) == False
 
 
-def test_has_at_least_one_issue_from_rules() -> None:
+def test_registration_without_summary() -> None:
     result_report = Result()
 
     result_report.register_checker_bundle(


### PR DESCRIPTION
**Description**

Make summary optional when registering checkers and checker bundles as it's not mandatory for users to set it.

There will be another PR to automatically create a summary and append it to the summary created by users.

**Main changes**

1. Make summary optional when registering checkers and checker bundles

**How was the PR tested?**

1. Unit-test

**Notes**

Related issue:
* https://github.com/asam-ev/qc-framework/issues/161
