### PR TITLE
Add methods to generate summary and add summary

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -86,6 +86,11 @@ class Result:
             self._report_results = result.CheckerResults.from_xml(xml_text)
 
     def write_to_file(self, xml_output_file_path: str, generate_summary=False) -> None:
+        """
+        generate_summary : bool
+            Automatically generate a summary for each checker and checker bundle.
+            The generated summary will be appended to the current summary.
+        """
         if self._report_results is None:
             raise RuntimeError(
                 "Report dump with empty report, the report needs to be loaded first"
@@ -216,6 +221,10 @@ class Result:
     def add_checker_bundle_summary(
         self, checker_bundle_name: str, content: str
     ) -> None:
+        """
+        Add content to the existing summary of a checker bundle.
+        The content will be appended to the current summary.
+        """
         bundle = self._get_checker_bundle(checker_bundle_name)
         if bundle.summary == "":
             bundle.summary = content
@@ -225,6 +234,10 @@ class Result:
     def add_checker_summary(
         self, checker_bundle_name: str, checker_id: str, content: str
     ) -> None:
+        """
+        Add content to the existing summary of a checker.
+        The content will be appended to the current summary.
+        """
         bundle = self._get_checker_bundle(checker_bundle_name)
         checker = self._get_checker(bundle, checker_id)
         if checker.summary == "":

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <CheckerResults version="0.0.1">
-  <CheckerBundle build_date="2024-05-31" description="Example checker bundle" name="TestBundle" version="0.0.1" summary="Tested example checkers">
-    <Checker status="completed" checkerId="TestChecker" description="Test checker" summary="Executed evaluation">
+  <CheckerBundle build_date="2024-05-31" description="Example checker bundle" name="TestBundle" version="0.0.1" summary="Tested example checkers. Extra summary for checker bundle. 1 checker(s) are executed. 1 checker(s) are completed. 0 checker(s) are skipped. 0 checker(s) have internal error and 0 checker(s) do not contain status.">
+    <Checker status="completed" checkerId="TestChecker" description="Test checker" summary="Executed evaluation. Extra summary for checker. 1 issue(s) are found.">
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue issueId="0" description="Issue found at odr" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
         <Locations description="Location for issue">

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -48,14 +48,14 @@ def test_result_write() -> None:
         build_date="2024-05-31",
         description="Example checker bundle",
         version="0.0.1",
-        summary="Tested example checkers",
+        summary="Tested example checkers.",
     )
 
     result.register_checker(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",
         description="Test checker",
-        summary="Executed evaluation",
+        summary="Executed evaluation.",
     )
 
     rule_uid = result.register_rule(
@@ -113,7 +113,16 @@ def test_result_write() -> None:
         status=StatusType.COMPLETED,
     )
 
-    result.write_to_file(TEST_REPORT_OUTPUT_PATH)
+    result.add_checker_bundle_summary(
+        checker_bundle_name="TestBundle", content="Extra summary for checker bundle."
+    )
+    result.add_checker_summary(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        content="Extra summary for checker.",
+    )
+
+    result.write_to_file(TEST_REPORT_OUTPUT_PATH, generate_summary=True)
 
     example_xml_text = ""
     output_xml_text = ""


### PR DESCRIPTION
**Description**

Add an option to generate summaries for checker bundles and checkers automatically when `write_to_file` and add methods to add summaries to checker bundle and checker. 

**Main changes**

1. Add an option to generate summaries for checker bundles and checkers automatically when `write_to_file`.
2. Add methods to add summaries to checker bundles and checkers. 

**How was the PR tested?**

1. Unit-test

**Notes**

Related issues:
* https://github.com/asam-ev/qc-framework/issues/161
