### PR TITLE
Add methods to add parameters on Result

### DIFF
--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from typing import Union, List
+from typing import Union, List, Dict
 from .models import config, common, IssueSeverity
 
 
@@ -108,6 +108,12 @@ class Configuration:
             return None
 
         return param.value
+
+    def get_all_global_config_param(self) -> Dict[str, Union[str, int, float]]:
+        params = {}
+        for param in self._configuration.params:
+            params[param.name] = param.value
+        return params
 
     def get_checker_bundle_param(
         self, checker_bundle_name: str, param_name: str

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -195,6 +195,7 @@ class StatusType(str, enum.Enum):
 
 
 class CheckerType(BaseXmlModel, validate_assignment=True, search_mode="unordered"):
+    params: List[ParamType] = element(tag="Param", default=[])
     addressed_rule: List[RuleType] = element(tag="AddressedRule", default=[])
     issues: List[IssueType] = element(tag="Issue", default=[])
     metadata: List[MetadataType] = element(tag="Metadata", default=[])

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -706,7 +706,7 @@ class Result:
 
     def get_param_from_checker_bundle(
         self, checker_bundle_name: str, param_name: str
-    ) -> None:
+    ) -> Union[int, str, float, None]:
         bundle = self._get_checker_bundle(checker_bundle_name)
 
         if len(bundle.params) == 0:
@@ -735,7 +735,7 @@ class Result:
 
     def get_param_from_checker(
         self, checker_bundle_name: str, checker_id: str, param_name: str
-    ) -> None:
+    ) -> Union[int, str, float, None]:
         bundle = self._get_checker_bundle(checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
 

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -3,12 +3,16 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import logging
+
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Union, List, Set
 from lxml import etree
-from .models import IssueSeverity, StatusType, result
-import logging
+
+from qc_baselib import Configuration
+from .models import IssueSeverity, StatusType, result, common
+
 
 REPORT_OUTPUT_FORMAT = "xqar"
 DEFAULT_REPORT_VERSION = "0.0.1"
@@ -117,11 +121,11 @@ class Result:
             )
 
         full_text = """
-            This is the automatically generated documentation. 
-            The lists of checkers and addressed rules were exported from the 
-            information registered in the Result object for a particular run. 
-            Therefore, some checkers and addressed rules might be missing if 
-            they are not registered in that particular run. Double check with 
+            This is the automatically generated documentation.
+            The lists of checkers and addressed rules were exported from the
+            information registered in the Result object for a particular run.
+            Therefore, some checkers and addressed rules might be missing if
+            they are not registered in that particular run. Double check with
             the implementation before using this generated documentation.\n\n"""
 
         for bundle in self._report_results.checker_bundles:
@@ -693,3 +697,94 @@ class Result:
                     return False
 
         return True
+
+    def add_param_to_checker_bundle(
+        self, checker_bundle_name: str, name: str, value: Union[str, int, float]
+    ) -> None:
+        bundle = self._get_checker_bundle(checker_bundle_name)
+        bundle.params.append(common.ParamType(name=name, value=value))
+
+    def get_param_from_checker_bundle(
+        self, checker_bundle_name: str, param_name: str
+    ) -> None:
+        bundle = self._get_checker_bundle(checker_bundle_name)
+
+        if len(bundle.params) == 0:
+            return None
+
+        param = next(
+            (param for param in bundle.params if param_name == param.name),
+            None,
+        )
+
+        if param is None:
+            return None
+
+        return param.value
+
+    def add_param_to_checker(
+        self,
+        checker_bundle_name: str,
+        checker_id: str,
+        name: str,
+        value: Union[str, int, float],
+    ) -> None:
+        bundle = self._get_checker_bundle(checker_bundle_name)
+        checker = self._get_checker(bundle=bundle, checker_id=checker_id)
+        checker.params.append(common.ParamType(name=name, value=value))
+
+    def get_param_from_checker(
+        self, checker_bundle_name: str, checker_id: str, param_name: str
+    ) -> None:
+        bundle = self._get_checker_bundle(checker_bundle_name)
+        checker = self._get_checker(bundle=bundle, checker_id=checker_id)
+
+        if len(checker.params) == 0:
+            return None
+
+        param = next(
+            (param for param in checker.params if param_name == param.name),
+            None,
+        )
+
+        if param is None:
+            return None
+
+        return param.value
+
+    def copy_param_from_config(self, config: Configuration) -> None:
+        # Inject global Configuration parameters to Result checker bundles
+        for param_name, param_value in config.get_all_global_config_param().items():
+            result_checker_bundles = self._report_results.checker_bundles
+            for bundle in result_checker_bundles:
+                bundle.params.append(
+                    common.ParamType(name=param_name, value=param_value)
+                )
+
+        # Copy Configuration checker bundle and checker parameters to Result
+        for config_bundle in config.get_all_checker_bundles():
+            result_bundle = self._get_checker_bundle(
+                checker_bundle_name=config_bundle.application
+            )
+
+            if result_bundle is None:
+                continue
+
+            for param in config_bundle.params:
+                result_bundle.params.append(
+                    common.ParamType(name=param.name, value=param.value)
+                )
+
+            for config_checker in config_bundle.checkers:
+                result_checker = self._get_checker(
+                    bundle=result_bundle,
+                    checker_id=config_checker.checker_id,
+                )
+
+                if result_checker is None:
+                    continue
+
+                for param in config_checker.params:
+                    result_checker.params.append(
+                        common.ParamType(name=param.name, value=param.value)
+                    )

--- a/tests/data/result_markdown_docs.md
+++ b/tests/data/result_markdown_docs.md
@@ -1,9 +1,9 @@
 
-            This is the automatically generated documentation. 
-            The lists of checkers and addressed rules were exported from the 
-            information registered in the Result object for a particular run. 
-            Therefore, some checkers and addressed rules might be missing if 
-            they are not registered in that particular run. Double check with 
+            This is the automatically generated documentation.
+            The lists of checkers and addressed rules were exported from the
+            information registered in the Result object for a particular run.
+            Therefore, some checkers and addressed rules might be missing if
+            they are not registered in that particular run. Double check with
             the implementation before using this generated documentation.
 
 # Checker bundle: TestBundle

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -219,5 +219,5 @@ def test_get_all_global_param() -> None:
 
     assert len(all_global_params) == 3
     assert all_global_params["testConfigParamStr"] == "testValue"
-    assert all_global_params["testConfigParamInt"] == "1"
-    assert all_global_params["testConfigParamFloat"] == "2.0"
+    assert all_global_params["testConfigParamInt"] == 1
+    assert all_global_params["testConfigParamFloat"] == 2.0

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -206,3 +206,18 @@ def test_get_all_methods() -> None:
     assert len(config._configuration.checker_bundles) == len(
         config.get_all_checker_bundles()
     )
+
+
+def test_get_all_global_param() -> None:
+    config = Configuration()
+
+    config.set_config_param("testConfigParamStr", "testValue")
+    config.set_config_param("testConfigParamInt", 1)
+    config.set_config_param("testConfigParamFloat", 2.0)
+
+    all_global_params = config.get_all_global_config_param()
+
+    assert len(all_global_params) == 3
+    assert all_global_params["testConfigParamStr"] == "testValue"
+    assert all_global_params["testConfigParamInt"] == "1"
+    assert all_global_params["testConfigParamFloat"] == "2.0"

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -6,7 +6,6 @@ from qc_baselib.models import config, result
 from qc_baselib import Result, IssueSeverity, StatusType, Configuration
 
 
-TEST_DATA_BASE_PATH = "tests/data"
 DEMO_REPORT_PATH = "tests/data/demo_checker_bundle.xqar"
 EXTENDED_DEMO_REPORT_PATH = "tests/data/demo_checker_bundle_extended.xqar"
 EXAMPLE_OUTPUT_REPORT_PATH = "tests/data/result_test_output.xqar"

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -3,9 +3,10 @@ import pytest
 from lxml import etree
 from pydantic_core import ValidationError
 from qc_baselib.models import config, result
-from qc_baselib import Result, IssueSeverity, StatusType
+from qc_baselib import Result, IssueSeverity, StatusType, Configuration
 
 
+TEST_DATA_BASE_PATH = "tests/data"
 DEMO_REPORT_PATH = "tests/data/demo_checker_bundle.xqar"
 EXTENDED_DEMO_REPORT_PATH = "tests/data/demo_checker_bundle_extended.xqar"
 EXAMPLE_OUTPUT_REPORT_PATH = "tests/data/result_test_output.xqar"
@@ -1043,3 +1044,203 @@ def test_all_checkers_completed() -> None:
     )
 
     assert result_report.all_checkers_completed() == True
+
+
+def test_add_get_param_to_checker_bundle() -> None:
+    result = Result()
+    result.register_checker_bundle(
+        build_date="",
+        description="",
+        name="TestCheckerBundle",
+        version="",
+    )
+
+    result.add_param_to_checker_bundle(
+        checker_bundle_name="TestCheckerBundle", name="TestStrParam", value="TestStr"
+    )
+    result.add_param_to_checker_bundle(
+        checker_bundle_name="TestCheckerBundle", name="TestIntParam", value=1
+    )
+    result.add_param_to_checker_bundle(
+        checker_bundle_name="TestCheckerBundle", name="TestFloatParam", value=2.0
+    )
+
+    assert (
+        result.get_param_from_checker_bundle(
+            checker_bundle_name="TestCheckerBundle", param_name="TestStrParam"
+        )
+        == "TestStr"
+    )
+    assert (
+        result.get_param_from_checker_bundle(
+            checker_bundle_name="TestCheckerBundle", param_name="TestIntParam"
+        )
+        == 1
+    )
+    assert (
+        result.get_param_from_checker_bundle(
+            checker_bundle_name="TestCheckerBundle", param_name="TestFloatParam"
+        )
+        == 2.0
+    )
+
+
+def test_add_get_param_to_checker() -> None:
+    result = Result()
+    result.register_checker_bundle(
+        build_date="",
+        description="",
+        name="TestCheckerBundle",
+        version="",
+    )
+    result.register_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        description="",
+    )
+
+    result.add_param_to_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        name="TestStrParam",
+        value="TestStr",
+    )
+    result.add_param_to_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        name="TestIntParam",
+        value=1,
+    )
+    result.add_param_to_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        name="TestFloatParam",
+        value=2.0,
+    )
+
+    assert (
+        result.get_param_from_checker(
+            checker_bundle_name="TestCheckerBundle",
+            checker_id="TestChecker",
+            param_name="TestStrParam",
+        )
+        == "TestStr"
+    )
+    assert (
+        result.get_param_from_checker(
+            checker_bundle_name="TestCheckerBundle",
+            checker_id="TestChecker",
+            param_name="TestIntParam",
+        )
+        == 1
+    )
+    assert (
+        result.get_param_from_checker(
+            checker_bundle_name="TestCheckerBundle",
+            checker_id="TestChecker",
+            param_name="TestFloatParam",
+        )
+        == 2.0
+    )
+
+
+def test_result_config_param_copy() -> None:
+    config = Configuration()
+    config.register_checker_bundle(checker_bundle_name="TestCheckerBundle")
+    config.register_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        min_level=IssueSeverity.INFORMATION,
+        max_level=IssueSeverity.ERROR,
+    )
+
+    config.set_config_param(
+        name="testConfigParamStr",
+        value="testValue",
+    )
+    config.set_config_param(
+        name="testConfigParamInt",
+        value=1,
+    )
+    config.set_config_param(
+        name="testConfigParamFloat",
+        value=2.0,
+    )
+
+    config.set_checker_bundle_param(
+        checker_bundle_name="TestCheckerBundle",
+        name="testConfigParamStr",
+        value="testValue",
+    )
+    config.set_checker_bundle_param(
+        checker_bundle_name="TestCheckerBundle",
+        name="testConfigParamInt",
+        value=1,
+    )
+    config.set_checker_bundle_param(
+        checker_bundle_name="TestCheckerBundle",
+        name="testConfigParamFloat",
+        value=2.0,
+    )
+
+    config.set_checker_param(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        name="testConfigParamStr",
+        value="testValue",
+    )
+    config.set_checker_param(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        name="testConfigParamInt",
+        value=1,
+    )
+    config.set_checker_param(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        name="testConfigParamFloat",
+        value=2.0,
+    )
+
+    result = Result()
+    result.register_checker_bundle(
+        build_date="",
+        description="",
+        name="TestCheckerBundle",
+        version="",
+    )
+    result.register_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+        description="",
+    )
+
+    result.copy_param_from_config(config=config)
+
+    test_bundle = result.get_checker_bundle_result(
+        checker_bundle_name="TestCheckerBundle"
+    )
+    test_checker = result.get_checker_result(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="TestChecker",
+    )
+    config_bundle = config._get_checker_bundle(checker_bundle_name="TestCheckerBundle")
+    config_checker = next(
+        (
+            checker
+            for checker in config_bundle.checkers
+            if checker.checker_id == "TestChecker"
+        ),
+        None,
+    )
+
+    assert len(test_bundle.params) == len(config_bundle.params) + len(
+        config._configuration.params
+    )
+    assert len(test_checker.params) == len(config_checker.params)
+
+    assert test_bundle.params[0].name == config_bundle.params[0].name
+    assert test_bundle.params[0].value == config_bundle.params[0].value
+
+    assert test_checker.params[0].name == config_checker.params[0].name
+    assert test_checker.params[0].value == config_checker.params[0].value


### PR DESCRIPTION
**Description**

This PR adds some methods to add and get parameters on the Result object.

It also include a change in the Configuration for supporting the new Result copy method.

**Main changes**

1. [Add params xml Param attribute to CheckerType model](https://github.com/asam-ev/qc-baselib-py/commit/e8d1d805131867a8ff321582d97789aee7fcdc21) 
2. [Add method to get all global configuration params from Configuration](https://github.com/asam-ev/qc-baselib-py/commit/a019bc597bee9692b047628a750c876ff81a5372) 
3. [Add complete copy configuration to Result](https://github.com/asam-ev/qc-baselib-py/commit/20d62b927f9110bf0080430c491f9ce73338a405) 
4. [Add test to new parameter methods on Result](https://github.com/asam-ev/qc-baselib-py/commit/f98f7e56bb7967d11c33087b6b3927388ab95685) 
5. [Add test to get global params on Configuration](https://github.com/asam-ev/qc-baselib-py/commit/3086b10ea9f7c36e5afcc00a85a75db5e2580cc5) 

**How was the PR tested?**

1. Unit-test.

**Notes**
- None.