### PR TITLE
Add duplicate validation to registration methods

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -327,7 +327,7 @@ class Result:
         for existing_bundle in self._report_results.checker_bundles:
             if existing_bundle.name == name:
                 raise RuntimeError(
-                    f"Checker bundle with name {name} already registered to results"
+                    f"Checker bundle with name {name} is already registered to results"
                 )
 
         self._report_results.checker_bundles.append(bundle)
@@ -349,7 +349,7 @@ class Result:
         for existing_checker in bundle.checkers:
             if existing_checker.checker_id == checker_id:
                 raise RuntimeError(
-                    f"Checker with id {checker_id} already registered to bundle {bundle.name}"
+                    f"Checker with id {checker_id} is already registered to bundle {bundle.name}"
                 )
 
         bundle.checkers.append(checker)
@@ -717,7 +717,7 @@ class Result:
         for exiting_param in bundle.params:
             if exiting_param.name == name:
                 raise RuntimeError(
-                    f"Param with name {name} already registered to bundle {checker_bundle_name}"
+                    f"Param with name {name} is already registered to bundle {checker_bundle_name}"
                 )
         bundle.params.append(common.ParamType(name=name, value=value))
 
@@ -751,7 +751,7 @@ class Result:
         for exiting_param in checker.params:
             if exiting_param.name == name:
                 raise RuntimeError(
-                    f"Param with name {name} already registered to checker {checker_id} on bundle {checker_bundle_name}"
+                    f"Param with name {name} is already registered to checker {checker_id} on bundle {checker_bundle_name}"
                 )
         checker.params.append(common.ParamType(name=name, value=value))
 

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -324,6 +324,12 @@ class Result:
         if self._report_results is None:
             self._report_results = result.CheckerResults(version=DEFAULT_REPORT_VERSION)
 
+        for existing_bundle in self._report_results.checker_bundles:
+            if existing_bundle.name == name:
+                raise RuntimeError(
+                    f"Checker bundle with name {name} already registered to results"
+                )
+
         self._report_results.checker_bundles.append(bundle)
 
     def register_checker(
@@ -339,6 +345,12 @@ class Result:
         )
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
+
+        for existing_checker in bundle.checkers:
+            if existing_checker.checker_id == checker_id:
+                raise RuntimeError(
+                    f"Checker with id {checker_id} already registered to bundle {bundle.name}"
+                )
 
         bundle.checkers.append(checker)
 
@@ -702,6 +714,11 @@ class Result:
         self, checker_bundle_name: str, name: str, value: Union[str, int, float]
     ) -> None:
         bundle = self._get_checker_bundle(checker_bundle_name)
+        for exiting_param in bundle.params:
+            if exiting_param.name == name:
+                raise RuntimeError(
+                    f"Param with name {name} already registered to bundle {checker_bundle_name}"
+                )
         bundle.params.append(common.ParamType(name=name, value=value))
 
     def get_param_from_checker_bundle(
@@ -731,6 +748,11 @@ class Result:
     ) -> None:
         bundle = self._get_checker_bundle(checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
+        for exiting_param in checker.params:
+            if exiting_param.name == name:
+                raise RuntimeError(
+                    f"Param with name {name} already registered to checker {checker_id} on bundle {checker_bundle_name}"
+                )
         checker.params.append(common.ParamType(name=name, value=value))
 
     def get_param_from_checker(

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1267,7 +1267,7 @@ def test_registering_checker_bundle_twice() -> None:
         )
 
     assert (
-        f"Checker bundle with name {bundle_name} already registered to results"
+        f"Checker bundle with name {bundle_name} is already registered to results"
         in str(exc_info.value)
     )
 
@@ -1300,7 +1300,7 @@ def test_registering_checker_twice() -> None:
         )
 
     assert (
-        f"Checker with id {checker_id} already registered to bundle {bundle_name}"
+        f"Checker with id {checker_id} is already registered to bundle {bundle_name}"
         in str(exc_info.value)
     )
 
@@ -1331,7 +1331,7 @@ def test_registering_checker_bundle_param_twice() -> None:
         )
 
     assert (
-        f"Param with name {param_name} already registered to bundle {bundle_name}"
+        f"Param with name {param_name} is already registered to bundle {bundle_name}"
         in str(exc_info.value)
     )
 
@@ -1372,6 +1372,6 @@ def test_registering_checker_param_twice() -> None:
         )
 
     assert (
-        f"Param with name {param_name} already registered to checker {checker_id} on bundle {bundle_name}"
+        f"Param with name {param_name} is already registered to checker {checker_id} on bundle {bundle_name}"
         in str(exc_info.value)
     )

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -693,14 +693,14 @@ def test_has_issue_in_rules() -> None:
 
     result_report.register_checker(
         checker_bundle_name="TestBundle",
-        checker_id="TestChecker",
+        checker_id="TestChecker2",
         description="Test checker",
         summary="Executed evaluation",
     )
 
     rule_uid_2 = result_report.register_rule(
         checker_bundle_name="TestBundle",
-        checker_id="TestChecker",
+        checker_id="TestChecker2",
         emanating_entity="test.com",
         standard="qc",
         definition_setting="1.0.0",
@@ -709,7 +709,7 @@ def test_has_issue_in_rules() -> None:
 
     result_report.register_issue(
         checker_bundle_name="TestBundle",
-        checker_id="TestChecker",
+        checker_id="TestChecker2",
         description="Issue found at odr",
         level=IssueSeverity.INFORMATION,
         rule_uid=rule_uid_2,
@@ -1243,3 +1243,135 @@ def test_result_config_param_copy() -> None:
 
     assert test_checker.params[0].name == config_checker.params[0].name
     assert test_checker.params[0].value == config_checker.params[0].value
+
+
+def test_registering_checker_bundle_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+    assert (
+        f"Checker bundle with name {bundle_name} already registered to results"
+        in str(exc_info.value)
+    )
+
+
+def test_registering_checker_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+        checker_id = "TestChecker"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.register_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            description="Test checker",
+            summary="Executed evaluation",
+        )
+        result_report.register_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            description="Test checker",
+            summary="Executed evaluation",
+        )
+
+    assert (
+        f"Checker with id {checker_id} already registered to bundle {bundle_name}"
+        in str(exc_info.value)
+    )
+
+
+def test_registering_checker_bundle_param_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+        param_name = "TestFloatParam"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.add_param_to_checker_bundle(
+            checker_bundle_name=bundle_name,
+            name=param_name,
+            value=2.0,
+        )
+        result_report.add_param_to_checker_bundle(
+            checker_bundle_name=bundle_name,
+            name=param_name,
+            value=2.0,
+        )
+
+    assert (
+        f"Param with name {param_name} already registered to bundle {bundle_name}"
+        in str(exc_info.value)
+    )
+
+
+def test_registering_checker_param_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+        checker_id = "TestChecker"
+        param_name = "TestFloatParam"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.register_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            description="Test checker",
+            summary="Executed evaluation",
+        )
+
+        result_report.add_param_to_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            name=param_name,
+            value=2.0,
+        )
+        result_report.add_param_to_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            name=param_name,
+            value=2.0,
+        )
+
+    assert (
+        f"Param with name {param_name} already registered to checker {checker_id} on bundle {bundle_name}"
+        in str(exc_info.value)
+    )


### PR DESCRIPTION
**Description**

This PR adds the validation for the registration of duplicated:

- Checker bundles;
- Checkers;
- Parameters;

on the Result object.

**Main changes**

1. [Add duplicate validation on registration methods](https://github.com/asam-ev/qc-baselib-py/commit/633936a5c8d758ed42d5fc91a6ca2f28f293b7f0)
2. [Add tests for new validation behavior](https://github.com/asam-ev/qc-baselib-py/commit/d1e3e8b44cffa9839e5662ae5c3f9338272bfcd1)

**How was the PR tested?**

1. Unit-test.

**Notes**
- None.