### PR TITLE
Add maintenance work

### DIFF
--- a/examples/json_validator/README.md
+++ b/examples/json_validator/README.md
@@ -35,8 +35,7 @@ options:
 - No issues found
 
 ```
-$ python python json_validator.py \
-    -c config/valid.xml
+$ python json_validator.py -c config/valid.xml
 2024-08-05 10:38:07,978 - Initializing checks
 2024-08-05 10:38:07,979 - JsonFile = data/valid.json
 2024-08-05 10:38:07,979 - resultFile = json_bundle_report.xqar
@@ -48,8 +47,7 @@ $ python python json_validator.py \
 - Issues found on file
 
 ```
-$ python python json_validator.py \
-    -c config/invalid.xml
+$ python json_validator.py -c config/invalid.xml
 2024-08-05 10:38:11,946 - Initializing checks
 2024-08-05 10:38:11,946 - JsonFile = data/invalid.json
 2024-08-05 10:38:11,946 - resultFile = json_bundle_report.xqar

--- a/examples/json_validator/config/skipped.xml
+++ b/examples/json_validator/config/skipped.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Config>
+
+    <Param name="JsonFile" value="data/non_existing_file.json" />
+
+    <CheckerBundle application="jsonBundle">
+        <Param name="resultFile" value="json_bundle_report.xqar" />
+        <Checker checkerId="jsonChecker" maxLevel="1" minLevel="3" />
+    </CheckerBundle>
+
+
+    <ReportModule application="TextReport">
+        <Param name="strInputFile" value="Result.xqar" />
+        <Param name="strReportFile" value="Report.txt" />
+    </ReportModule>
+
+</Config>

--- a/examples/json_validator/requirements.txt
+++ b/examples/json_validator/requirements.txt
@@ -1,1 +1,1 @@
-qc_baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop
+asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from typing import Union, List
+from typing import Union, List, Dict
 from .models import config, common, IssueSeverity
 
 
@@ -108,6 +108,12 @@ class Configuration:
             return None
 
         return param.value
+
+    def get_all_global_config_param(self) -> Dict[str, Union[str, int, float]]:
+        params = {}
+        for param in self._configuration.params:
+            params[param.name] = param.value
+        return params
 
     def get_checker_bundle_param(
         self, checker_bundle_name: str, param_name: str

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -195,6 +195,7 @@ class StatusType(str, enum.Enum):
 
 
 class CheckerType(BaseXmlModel, validate_assignment=True, search_mode="unordered"):
+    params: List[ParamType] = element(tag="Param", default=[])
     addressed_rule: List[RuleType] = element(tag="AddressedRule", default=[])
     issues: List[IssueType] = element(tag="Issue", default=[])
     metadata: List[MetadataType] = element(tag="Metadata", default=[])

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -391,6 +391,35 @@ class Result:
 
         return rule.rule_uid
 
+    def register_rule_by_uid(
+        self,
+        checker_bundle_name: str,
+        checker_id: str,
+        rule_uid: str,
+    ) -> None:
+        """
+        Rule uid will be registered to checker.
+
+        Rule uid needs to follow the proper schema, more information at:
+        https://github.com/asam-ev/qc-framework/blob/main/doc/manual/rule_uid_schema.md
+        """
+
+        splitted_uid = rule_uid.split(":")
+
+        if len(splitted_uid) < 4:
+            raise RuntimeError(
+                f"Invalid rule uid: {rule_uid}. The uid should be composed by 4 entities separated by ':'."
+            )
+
+        self.register_rule(
+            checker_bundle_name=checker_bundle_name,
+            checker_id=checker_id,
+            emanating_entity=splitted_uid[0],
+            standard=splitted_uid[1],
+            definition_setting=splitted_uid[2],
+            rule_full_name=splitted_uid[3],
+        )
+
     def register_issue(
         self,
         checker_bundle_name: str,

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -324,6 +324,12 @@ class Result:
         if self._report_results is None:
             self._report_results = result.CheckerResults(version=DEFAULT_REPORT_VERSION)
 
+        for existing_bundle in self._report_results.checker_bundles:
+            if existing_bundle.name == name:
+                raise RuntimeError(
+                    f"Checker bundle with name {name} is already registered to results"
+                )
+
         self._report_results.checker_bundles.append(bundle)
 
     def register_checker(
@@ -339,6 +345,12 @@ class Result:
         )
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
+
+        for existing_checker in bundle.checkers:
+            if existing_checker.checker_id == checker_id:
+                raise RuntimeError(
+                    f"Checker with id {checker_id} is already registered to bundle {bundle.name}"
+                )
 
         bundle.checkers.append(checker)
 
@@ -702,6 +714,11 @@ class Result:
         self, checker_bundle_name: str, name: str, value: Union[str, int, float]
     ) -> None:
         bundle = self._get_checker_bundle(checker_bundle_name)
+        for exiting_param in bundle.params:
+            if exiting_param.name == name:
+                raise RuntimeError(
+                    f"Param with name {name} is already registered to bundle {checker_bundle_name}"
+                )
         bundle.params.append(common.ParamType(name=name, value=value))
 
     def get_param_from_checker_bundle(
@@ -731,6 +748,11 @@ class Result:
     ) -> None:
         bundle = self._get_checker_bundle(checker_bundle_name)
         checker = self._get_checker(bundle=bundle, checker_id=checker_id)
+        for exiting_param in checker.params:
+            if exiting_param.name == name:
+                raise RuntimeError(
+                    f"Param with name {name} is already registered to checker {checker_id} on bundle {checker_bundle_name}"
+                )
         checker.params.append(common.ParamType(name=name, value=value))
 
     def get_param_from_checker(

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -249,7 +249,9 @@ class Result:
         else:
             checker.summary += f" {content}"
 
-    def _get_checker_bundle(self, checker_bundle_name: str) -> result.CheckerBundleType:
+    def _get_checker_bundle_without_error(
+        self, checker_bundle_name: str
+    ) -> Union[None, result.CheckerBundleType]:
         if self._report_results is None:
             raise RuntimeError(
                 "Report not initialized. Initialize the report first by registering the version or a checker bundle."
@@ -264,6 +266,11 @@ class Result:
             None,
         )
 
+        return bundle
+
+    def _get_checker_bundle(self, checker_bundle_name: str) -> result.CheckerBundleType:
+        bundle = self._get_checker_bundle_without_error(checker_bundle_name)
+
         if bundle is None:
             raise RuntimeError(
                 f"Bundle not found. The specified {checker_bundle_name} does not exist on the report. Register the bundle first."
@@ -271,9 +278,9 @@ class Result:
 
         return bundle
 
-    def _get_checker(
+    def _get_checker_without_error(
         self, bundle: result.CheckerBundleType, checker_id: str
-    ) -> result.CheckerType:
+    ) -> Union[None, result.CheckerType]:
         checker = next(
             (
                 checker
@@ -282,6 +289,13 @@ class Result:
             ),
             None,
         )
+
+        return checker
+
+    def _get_checker(
+        self, bundle: result.CheckerBundleType, checker_id: str
+    ) -> result.CheckerType:
+        checker = self._get_checker_without_error(bundle, checker_id)
 
         if checker is None:
             raise RuntimeError(
@@ -814,7 +828,7 @@ class Result:
 
         # Copy Configuration checker bundle and checker parameters to Result
         for config_bundle in config.get_all_checker_bundles():
-            result_bundle = self._get_checker_bundle(
+            result_bundle = self._get_checker_bundle_without_error(
                 checker_bundle_name=config_bundle.application
             )
 
@@ -827,7 +841,7 @@ class Result:
                 )
 
             for config_checker in config_bundle.checkers:
-                result_checker = self._get_checker(
+                result_checker = self._get_checker_without_error(
                     bundle=result_bundle,
                     checker_id=config_checker.checker_id,
                 )

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -85,11 +85,21 @@ class Result:
             xml_text = report_xml_file.read()
             self._report_results = result.CheckerResults.from_xml(xml_text)
 
-    def write_to_file(self, xml_output_file_path: str) -> None:
+    def write_to_file(self, xml_output_file_path: str, generate_summary=False) -> None:
+        """
+        generate_summary : bool
+            Automatically generate a summary for each checker and checker bundle.
+            The generated summary will be appended to the current summary.
+        """
         if self._report_results is None:
             raise RuntimeError(
                 "Report dump with empty report, the report needs to be loaded first"
             )
+
+        if generate_summary:
+            self._generate_checker_bundle_summary()
+            self._generate_checker_summary()
+
         with open(xml_output_file_path, "wb") as report_xml_file:
             xml_text = self._report_results.to_xml(
                 pretty_print=True,
@@ -165,6 +175,75 @@ class Result:
             self._report_results = result.CheckerBundleType(version=version)
         else:
             self._report_results.version = version
+
+    def _generate_checker_bundle_summary(self) -> None:
+        for bundle in self._report_results.checker_bundles:
+            number_of_checkers = 0
+            number_of_completed_checkers = 0
+            number_of_skipped_checkers = 0
+            number_of_error_checkers = 0
+            number_of_no_status_checkers = 0
+
+            for checker in bundle.checkers:
+                number_of_checkers += 1
+                if checker.status == StatusType.COMPLETED:
+                    number_of_completed_checkers += 1
+                elif checker.status == StatusType.SKIPPED:
+                    number_of_skipped_checkers += 1
+                elif checker.status == StatusType.ERROR:
+                    number_of_error_checkers += 1
+                else:
+                    number_of_no_status_checkers += 1
+
+            summary = (
+                f"{number_of_checkers} checker(s) are executed. "
+                f"{number_of_completed_checkers} checker(s) are completed. {number_of_skipped_checkers} checker(s) are skipped. "
+                f"{number_of_error_checkers} checker(s) have internal error and {number_of_no_status_checkers} checker(s) do not contain status."
+            )
+
+            if bundle.summary == "":
+                bundle.summary = summary
+            else:
+                bundle.summary += f" {summary}"
+
+    def _generate_checker_summary(self) -> None:
+        for bundle in self._report_results.checker_bundles:
+            for checker in bundle.checkers:
+                number_of_issues = len(checker.issues)
+
+                summary = f"{number_of_issues} issue(s) are found."
+
+                if checker.summary == "":
+                    checker.summary = summary
+                else:
+                    checker.summary += f" {summary}"
+
+    def add_checker_bundle_summary(
+        self, checker_bundle_name: str, content: str
+    ) -> None:
+        """
+        Add content to the existing summary of a checker bundle.
+        The content will be appended to the current summary.
+        """
+        bundle = self._get_checker_bundle(checker_bundle_name)
+        if bundle.summary == "":
+            bundle.summary = content
+        else:
+            bundle.summary += f" {content}"
+
+    def add_checker_summary(
+        self, checker_bundle_name: str, checker_id: str, content: str
+    ) -> None:
+        """
+        Add content to the existing summary of a checker.
+        The content will be appended to the current summary.
+        """
+        bundle = self._get_checker_bundle(checker_bundle_name)
+        checker = self._get_checker(bundle, checker_id)
+        if checker.summary == "":
+            checker.summary = content
+        else:
+            checker.summary += f" {content}"
 
     def _get_checker_bundle(self, checker_bundle_name: str) -> result.CheckerBundleType:
         if self._report_results is None:

--- a/tests/data/result_markdown_docs.md
+++ b/tests/data/result_markdown_docs.md
@@ -1,9 +1,9 @@
 
-            This is the automatically generated documentation. 
-            The lists of checkers and addressed rules were exported from the 
-            information registered in the Result object for a particular run. 
-            Therefore, some checkers and addressed rules might be missing if 
-            they are not registered in that particular run. Double check with 
+            This is the automatically generated documentation.
+            The lists of checkers and addressed rules were exported from the
+            information registered in the Result object for a particular run.
+            Therefore, some checkers and addressed rules might be missing if
+            they are not registered in that particular run. Double check with
             the implementation before using this generated documentation.
 
 # Checker bundle: TestBundle

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <CheckerResults version="0.0.1">
-  <CheckerBundle build_date="2024-05-31" description="Example checker bundle" name="TestBundle" version="0.0.1" summary="Tested example checkers">
-    <Checker status="completed" checkerId="TestChecker" description="Test checker" summary="Executed evaluation">
+  <CheckerBundle build_date="2024-05-31" description="Example checker bundle" name="TestBundle" version="0.0.1" summary="Tested example checkers. Extra summary for checker bundle. 1 checker(s) are executed. 1 checker(s) are completed. 0 checker(s) are skipped. 0 checker(s) have internal error and 0 checker(s) do not contain status.">
+    <Checker status="completed" checkerId="TestChecker" description="Test checker" summary="Executed evaluation. Extra summary for checker. 1 issue(s) are found.">
       <AddressedRule ruleUID="test.com:qc:1.0.0:qwerty.qwerty"/>
       <Issue issueId="0" description="Issue found at odr" level="3" ruleUID="test.com:qc:1.0.0:qwerty.qwerty">
         <Locations description="Location for issue">

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -206,3 +206,18 @@ def test_get_all_methods() -> None:
     assert len(config._configuration.checker_bundles) == len(
         config.get_all_checker_bundles()
     )
+
+
+def test_get_all_global_param() -> None:
+    config = Configuration()
+
+    config.set_config_param("testConfigParamStr", "testValue")
+    config.set_config_param("testConfigParamInt", 1)
+    config.set_config_param("testConfigParamFloat", 2.0)
+
+    all_global_params = config.get_all_global_config_param()
+
+    assert len(all_global_params) == 3
+    assert all_global_params["testConfigParamStr"] == "testValue"
+    assert all_global_params["testConfigParamInt"] == 1
+    assert all_global_params["testConfigParamFloat"] == 2.0

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -48,14 +48,14 @@ def test_result_write() -> None:
         build_date="2024-05-31",
         description="Example checker bundle",
         version="0.0.1",
-        summary="Tested example checkers",
+        summary="Tested example checkers.",
     )
 
     result.register_checker(
         checker_bundle_name="TestBundle",
         checker_id="TestChecker",
         description="Test checker",
-        summary="Executed evaluation",
+        summary="Executed evaluation.",
     )
 
     rule_uid = result.register_rule(
@@ -113,7 +113,16 @@ def test_result_write() -> None:
         status=StatusType.COMPLETED,
     )
 
-    result.write_to_file(TEST_REPORT_OUTPUT_PATH)
+    result.add_checker_bundle_summary(
+        checker_bundle_name="TestBundle", content="Extra summary for checker bundle."
+    )
+    result.add_checker_summary(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        content="Extra summary for checker.",
+    )
+
+    result.write_to_file(TEST_REPORT_OUTPUT_PATH, generate_summary=True)
 
     example_xml_text = ""
     output_xml_text = ""

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1201,6 +1201,21 @@ def test_result_config_param_copy() -> None:
         value=2.0,
     )
 
+    config.register_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="FirstNonExistingTestChecker",
+        min_level=IssueSeverity.INFORMATION,
+        max_level=IssueSeverity.ERROR,
+    )
+
+    config.register_checker_bundle(checker_bundle_name="NonExistingTestCheckerBundle")
+    config.register_checker(
+        checker_bundle_name="NonExistingTestCheckerBundle",
+        checker_id="SecondNonExistingTestChecker",
+        min_level=IssueSeverity.INFORMATION,
+        max_level=IssueSeverity.ERROR,
+    )
+
     result = Result()
     result.register_checker_bundle(
         build_date="",

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -693,14 +693,14 @@ def test_has_issue_in_rules() -> None:
 
     result_report.register_checker(
         checker_bundle_name="TestBundle",
-        checker_id="TestChecker",
+        checker_id="TestChecker2",
         description="Test checker",
         summary="Executed evaluation",
     )
 
     rule_uid_2 = result_report.register_rule(
         checker_bundle_name="TestBundle",
-        checker_id="TestChecker",
+        checker_id="TestChecker2",
         emanating_entity="test.com",
         standard="qc",
         definition_setting="1.0.0",
@@ -709,7 +709,7 @@ def test_has_issue_in_rules() -> None:
 
     result_report.register_issue(
         checker_bundle_name="TestBundle",
-        checker_id="TestChecker",
+        checker_id="TestChecker2",
         description="Issue found at odr",
         level=IssueSeverity.INFORMATION,
         rule_uid=rule_uid_2,
@@ -1243,3 +1243,135 @@ def test_result_config_param_copy() -> None:
 
     assert test_checker.params[0].name == config_checker.params[0].name
     assert test_checker.params[0].value == config_checker.params[0].value
+
+
+def test_registering_checker_bundle_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+    assert (
+        f"Checker bundle with name {bundle_name} is already registered to results"
+        in str(exc_info.value)
+    )
+
+
+def test_registering_checker_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+        checker_id = "TestChecker"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.register_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            description="Test checker",
+            summary="Executed evaluation",
+        )
+        result_report.register_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            description="Test checker",
+            summary="Executed evaluation",
+        )
+
+    assert (
+        f"Checker with id {checker_id} is already registered to bundle {bundle_name}"
+        in str(exc_info.value)
+    )
+
+
+def test_registering_checker_bundle_param_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+        param_name = "TestFloatParam"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.add_param_to_checker_bundle(
+            checker_bundle_name=bundle_name,
+            name=param_name,
+            value=2.0,
+        )
+        result_report.add_param_to_checker_bundle(
+            checker_bundle_name=bundle_name,
+            name=param_name,
+            value=2.0,
+        )
+
+    assert (
+        f"Param with name {param_name} is already registered to bundle {bundle_name}"
+        in str(exc_info.value)
+    )
+
+
+def test_registering_checker_param_twice() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        result_report = Result()
+        bundle_name = "TestBundle"
+        checker_id = "TestChecker"
+        param_name = "TestFloatParam"
+
+        result_report.register_checker_bundle(
+            name=bundle_name,
+            build_date="2024-05-31",
+            description="Example checker bundle",
+            version="0.0.1",
+            summary="Tested example checkers",
+        )
+
+        result_report.register_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            description="Test checker",
+            summary="Executed evaluation",
+        )
+
+        result_report.add_param_to_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            name=param_name,
+            value=2.0,
+        )
+        result_report.add_param_to_checker(
+            checker_bundle_name=bundle_name,
+            checker_id=checker_id,
+            name=param_name,
+            value=2.0,
+        )
+
+    assert (
+        f"Param with name {param_name} is already registered to checker {checker_id} on bundle {bundle_name}"
+        in str(exc_info.value)
+    )


### PR DESCRIPTION
**Description**

This PR adds various minor maintenance tasks.

**Main changes**

1. Update the checker bundle example to show how to set status of checker and how to add documentation generator.
    * #36 
1. Add a function to automatically generate the summary for each checker and checker bundle. Also add a function to allow users to add more information to the summary.
    * #37 
1. Support parameters for each checker and add a function to copy all parameters from a config file to a result file.
    * #38 
    * #42 
1. Add validation for duplicated registrations (like register the same checker twice).
    * #39 
1. Allow users to register rule by rule uid string directly.
    * #40 

**How was the PR tested?**

1. Tests are included in each PR.

**Notes**

This PR closes the following issue:
* https://github.com/asam-ev/qc-framework/issues/161
