### PR TITLE
Fix an issue in copy_param_from_config

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -249,7 +249,9 @@ class Result:
         else:
             checker.summary += f" {content}"
 
-    def _get_checker_bundle(self, checker_bundle_name: str) -> result.CheckerBundleType:
+    def _get_checker_bundle_without_error(
+        self, checker_bundle_name: str
+    ) -> Union[None, result.CheckerBundleType]:
         if self._report_results is None:
             raise RuntimeError(
                 "Report not initialized. Initialize the report first by registering the version or a checker bundle."
@@ -264,6 +266,11 @@ class Result:
             None,
         )
 
+        return bundle
+
+    def _get_checker_bundle(self, checker_bundle_name: str) -> result.CheckerBundleType:
+        bundle = self._get_checker_bundle_without_error(checker_bundle_name)
+
         if bundle is None:
             raise RuntimeError(
                 f"Bundle not found. The specified {checker_bundle_name} does not exist on the report. Register the bundle first."
@@ -271,9 +278,9 @@ class Result:
 
         return bundle
 
-    def _get_checker(
+    def _get_checker_without_error(
         self, bundle: result.CheckerBundleType, checker_id: str
-    ) -> result.CheckerType:
+    ) -> Union[None, result.CheckerType]:
         checker = next(
             (
                 checker
@@ -282,6 +289,13 @@ class Result:
             ),
             None,
         )
+
+        return checker
+
+    def _get_checker(
+        self, bundle: result.CheckerBundleType, checker_id: str
+    ) -> result.CheckerType:
+        checker = self._get_checker_without_error(bundle, checker_id)
 
         if checker is None:
             raise RuntimeError(
@@ -814,7 +828,7 @@ class Result:
 
         # Copy Configuration checker bundle and checker parameters to Result
         for config_bundle in config.get_all_checker_bundles():
-            result_bundle = self._get_checker_bundle(
+            result_bundle = self._get_checker_bundle_without_error(
                 checker_bundle_name=config_bundle.application
             )
 
@@ -827,7 +841,7 @@ class Result:
                 )
 
             for config_checker in config_bundle.checkers:
-                result_checker = self._get_checker(
+                result_checker = self._get_checker_without_error(
                     bundle=result_bundle,
                     checker_id=config_checker.checker_id,
                 )

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1201,6 +1201,21 @@ def test_result_config_param_copy() -> None:
         value=2.0,
     )
 
+    config.register_checker(
+        checker_bundle_name="TestCheckerBundle",
+        checker_id="FirstNonExistingTestChecker",
+        min_level=IssueSeverity.INFORMATION,
+        max_level=IssueSeverity.ERROR,
+    )
+
+    config.register_checker_bundle(checker_bundle_name="NonExistingTestCheckerBundle")
+    config.register_checker(
+        checker_bundle_name="NonExistingTestCheckerBundle",
+        checker_id="SecondNonExistingTestChecker",
+        min_level=IssueSeverity.INFORMATION,
+        max_level=IssueSeverity.ERROR,
+    )
+
     result = Result()
     result.register_checker_bundle(
         build_date="",


### PR DESCRIPTION
**Description**

This PR fixes an issue in the `copy_param_from_config` method. This method will raise an error in case a checker bundle or a checker in the config file is not registered in the result file. It is expected that there will be no error and the params are simply not copied in those cases.

**How was the PR tested?**

1. Unit-test

**Notes**
