### PR TITLE
Prepare for the release candidate 1.0.0rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ interacting with the configuration files and the results files from the
 ASAM Quality Checker Framework. With it, users can create their own
 Checker Bundles or Report Modules in Python.
 
+**Disclaimer**: The current version is the release candidate `1.0.0rc1`. The first official release is expected to be in November.
+
 The library features the main interfaces needed to implement a module:
 
 - Configuration: for reading and writing QC Framework [configuration files](https://github.com/asam-ev/qc-framework/blob/main/doc/manual/file_formats.md#configuration-file-xml).
@@ -108,7 +110,7 @@ content:
 </Config>
 ```
 
-For more information regarding the configuration XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/config_format.xsd)
+For more information regarding the configuration XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/config_format.xsd)
 
 ### Reading checker bundle config from file
 
@@ -242,7 +244,7 @@ content:
 
 ```
 
-For more information regarding the result XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/xqar_result_format.xsd)
+For more information regarding the result XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/xqar_result_format.xsd)
 
 ### Reading a result from checker bundle execution
 

--- a/examples/json_validator/requirements.txt
+++ b/examples/json_validator/requirements.txt
@@ -1,1 +1,1 @@
-asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop
+asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@main

--- a/examples/report_module_text/requirements.txt
+++ b/examples/report_module_text/requirements.txt
@@ -1,4 +1,4 @@
-qc_baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop
+asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@main
 lxml==5.2.2
 numpy==2.0.0
 scipy==1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asam-qc-baselib"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Python base library for ASAM Quality Checker Framework"
 authors = ["Patrick Abrahão <patrick@ivex.ai>"]
 license = "MPL-2.0"

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-__version__ = "0.1.0"
+__version__ = "1.0.0rc1"
 
 
 from .configuration import Configuration as Configuration

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -39,7 +39,7 @@ class Configuration:
     ```
 
     For more information regarding the configuration XSD schema you can check
-    [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/config_format.xsd).
+    [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/config_format.xsd).
 
     """
 

--- a/qc_baselib/models/config.py
+++ b/qc_baselib/models/config.py
@@ -11,7 +11,7 @@ from .common import ParamType, IssueSeverity
 
 # Configuration models
 # Original XSD file:
-# > https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/config_format.xsd
+# > https://github.com/asam-ev/qc-framework/blob/main/doc/schema/config_format.xsd
 
 
 class CheckerType(BaseXmlModel):

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -15,7 +15,7 @@ from .common import ParamType, IssueSeverity
 
 # Report models
 # Original XSD file:
-# > https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/xqar_report_format.xsd
+# > https://github.com/asam-ev/qc-framework/blob/main/doc/schema/xqar_report_format.xsd
 
 
 class XMLLocationType(BaseXmlModel):

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Union, List, Set
 from lxml import etree
+from datetime import datetime
 
 from qc_baselib import Configuration
 from .models import IssueSeverity, StatusType, result, common
@@ -48,7 +49,6 @@ class Result:
 
     result.register_checker_bundle(
         name="TestBundle",
-        build_date="2024-05-31",
         description="Example checker bundle",
         version="0.0.1",
     )
@@ -65,11 +65,11 @@ class Result:
 
     result.load_from_file(RESULT_FILE_PATH)
 
-    version = result.get_version()
+    version = result.get_result_version()
     ```
 
     For more information regarding the results report XSD schema you can check
-    [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/xqar_report_format.xsd)
+    [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/xqar_report_format.xsd)
 
     """
 
@@ -321,14 +321,18 @@ class Result:
 
     def register_checker_bundle(
         self,
-        build_date: str,
         description: str,
         name: str,
         version: str,
+        build_date: Union[None, str] = None,
         summary: str = "",
     ) -> None:
         bundle = result.CheckerBundleType(
-            build_date=build_date,
+            build_date=(
+                build_date
+                if build_date is not None
+                else datetime.today().strftime("%Y-%m-%d")
+            ),
             description=description,
             name=name,
             version=version,

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -2,7 +2,8 @@ import os
 import pytest
 from lxml import etree
 from pydantic_core import ValidationError
-from qc_baselib.models import config, result
+from datetime import datetime
+from qc_baselib.models import result
 from qc_baselib import Result, IssueSeverity, StatusType, Configuration
 
 
@@ -1503,3 +1504,19 @@ def test_create_rule_id_validation() -> None:
             checker_id="TestChecker",
             rule_uid="test.com:qc:1.0.0:",
         )
+
+
+def test_build_date() -> None:
+    result = Result()
+
+    result.register_checker_bundle(
+        name="TestBundle",
+        description="Example checker bundle",
+        version="0.0.1",
+    )
+
+    checker_bundle_result = result.get_checker_bundle_result("TestBundle")
+
+    print(checker_bundle_result.build_date)
+
+    assert checker_bundle_result.build_date == datetime.now().strftime("%Y-%m-%d")


### PR DESCRIPTION
**Description**

This PR prepares the release candidate 1.0.0rc1.

**Main changes**

1. Update all the reference to the main branch.
2. Add disclaimer about the release candidate.
3. Make `build_time` optional when registering checker bundle. If `build_time` is not provided, the current datetime will be used as build time (see https://github.com/asam-ev/qc-opendrive/issues/108)

**How was the PR tested?**

1. Unit-test

**Notes**
Related issue: https://github.com/asam-ev/qc-opendrive/issues/108