### PR TITLE
For CCB Review: Prepare for the release candidate v1.0.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ interacting with the configuration files and the results files from the
 ASAM Quality Checker Framework. With it, users can create their own
 Checker Bundles or Report Modules in Python.
 
+**Disclaimer**: The current version is the release candidate `1.0.0rc1`. The first official release is expected to be in November.
+
 The library features the main interfaces needed to implement a module:
 
 - Configuration: for reading and writing QC Framework [configuration files](https://github.com/asam-ev/qc-framework/blob/main/doc/manual/file_formats.md#configuration-file-xml).
@@ -108,7 +110,7 @@ content:
 </Config>
 ```
 
-For more information regarding the configuration XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/config_format.xsd)
+For more information regarding the configuration XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/config_format.xsd)
 
 ### Reading checker bundle config from file
 
@@ -242,7 +244,7 @@ content:
 
 ```
 
-For more information regarding the result XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/xqar_result_format.xsd)
+For more information regarding the result XSD schema you can check [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/xqar_result_format.xsd)
 
 ### Reading a result from checker bundle execution
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ interacting with the configuration files and the results files from the
 ASAM Quality Checker Framework. With it, users can create their own
 Checker Bundles or Report Modules in Python.
 
-**Disclaimer**: The current version is the release candidate `1.0.0rc1`. The first official release is expected to be in November.
+**Disclaimer**: The current version is a release candidate. The first official release is expected to be in November.
 
 The library features the main interfaces needed to implement a module:
 

--- a/examples/json_validator/requirements.txt
+++ b/examples/json_validator/requirements.txt
@@ -1,1 +1,1 @@
-asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop
+asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@main

--- a/examples/report_module_text/requirements.txt
+++ b/examples/report_module_text/requirements.txt
@@ -1,4 +1,4 @@
-qc_baselib @ git+https://github.com/asam-ev/qc-baselib-py@develop
+asam-qc-baselib @ git+https://github.com/asam-ev/qc-baselib-py@main
 lxml==5.2.2
 numpy==2.0.0
 scipy==1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asam-qc-baselib"
-version = "0.1.0"
+version = "1.0.0rc1"
 description = "Python base library for ASAM Quality Checker Framework"
 authors = ["Patrick Abrahão <patrick@ivex.ai>"]
 license = "MPL-2.0"

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-__version__ = "v1.0.0-rc.1"
+__version__ = "1.0.0rc1"
 
 
 from .configuration import Configuration as Configuration

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-__version__ = "1.0.0rc1"
+__version__ = "v1.0.0-rc.1"
 
 
 from .configuration import Configuration as Configuration

--- a/qc_baselib/__init__.py
+++ b/qc_baselib/__init__.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-__version__ = "0.1.0"
+__version__ = "1.0.0rc1"
 
 
 from .configuration import Configuration as Configuration

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -3,7 +3,7 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Optional
 from .models import config, common, IssueSeverity
 
 
@@ -46,7 +46,7 @@ class Configuration:
     def __init__(
         self,
     ):
-        self._configuration: Union[None, config.Config] = None
+        self._configuration: Optional[config.Config] = None
 
     def load_from_file(self, xml_file_path: str, override: bool = False) -> None:
         if self._configuration is not None and not override:
@@ -74,7 +74,7 @@ class Configuration:
 
     def _get_checker_bundle(
         self, checker_bundle_name: str
-    ) -> Union[config.CheckerBundleType, None]:
+    ) -> Optional[config.CheckerBundleType]:
         if len(self._configuration.checker_bundles) == 0:
             return None
 

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -39,7 +39,7 @@ class Configuration:
     ```
 
     For more information regarding the configuration XSD schema you can check
-    [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/config_format.xsd).
+    [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/config_format.xsd).
 
     """
 

--- a/qc_baselib/models/config.py
+++ b/qc_baselib/models/config.py
@@ -11,7 +11,7 @@ from .common import ParamType, IssueSeverity
 
 # Configuration models
 # Original XSD file:
-# > https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/config_format.xsd
+# > https://github.com/asam-ev/qc-framework/blob/main/doc/schema/config_format.xsd
 
 
 class CheckerType(BaseXmlModel):

--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -15,7 +15,7 @@ from .common import ParamType, IssueSeverity
 
 # Report models
 # Original XSD file:
-# > https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/xqar_report_format.xsd
+# > https://github.com/asam-ev/qc-framework/blob/main/doc/schema/xqar_report_format.xsd
 
 
 class XMLLocationType(BaseXmlModel):

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Union, List, Set
 from lxml import etree
+from datetime import datetime
 
 from qc_baselib import Configuration
 from .models import IssueSeverity, StatusType, result, common
@@ -48,7 +49,6 @@ class Result:
 
     result.register_checker_bundle(
         name="TestBundle",
-        build_date="2024-05-31",
         description="Example checker bundle",
         version="0.0.1",
     )
@@ -65,11 +65,11 @@ class Result:
 
     result.load_from_file(RESULT_FILE_PATH)
 
-    version = result.get_version()
+    version = result.get_result_version()
     ```
 
     For more information regarding the results report XSD schema you can check
-    [here](https://github.com/asam-ev/qc-framework/blob/develop/doc/schema/xqar_report_format.xsd)
+    [here](https://github.com/asam-ev/qc-framework/blob/main/doc/schema/xqar_report_format.xsd)
 
     """
 
@@ -321,14 +321,18 @@ class Result:
 
     def register_checker_bundle(
         self,
-        build_date: str,
         description: str,
         name: str,
         version: str,
+        build_date: Union[None, str] = None,
         summary: str = "",
     ) -> None:
         bundle = result.CheckerBundleType(
-            build_date=build_date,
+            build_date=(
+                build_date
+                if build_date is not None
+                else datetime.today().strftime("%Y-%m-%d")
+            ),
             description=description,
             name=name,
             version=version,

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -7,7 +7,7 @@ import logging
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Union, List, Set
+from typing import Union, List, Set, Optional
 from lxml import etree
 from datetime import datetime
 
@@ -76,7 +76,7 @@ class Result:
     def __init__(
         self,
     ):
-        self._report_results: Union[None, result.CheckerResults] = None
+        self._report_results: Optional[result.CheckerResults] = None
         self._id_manager = IDManager()
 
     def load_from_file(self, xml_file_path: str, override: bool = False) -> None:
@@ -251,7 +251,7 @@ class Result:
 
     def _get_checker_bundle_without_error(
         self, checker_bundle_name: str
-    ) -> Union[None, result.CheckerBundleType]:
+    ) -> Optional[result.CheckerBundleType]:
         if self._report_results is None:
             raise RuntimeError(
                 "Report not initialized. Initialize the report first by registering the version or a checker bundle."
@@ -280,7 +280,7 @@ class Result:
 
     def _get_checker_without_error(
         self, bundle: result.CheckerBundleType, checker_id: str
-    ) -> Union[None, result.CheckerType]:
+    ) -> Optional[result.CheckerType]:
         checker = next(
             (
                 checker
@@ -324,7 +324,7 @@ class Result:
         description: str,
         name: str,
         version: str,
-        build_date: Union[None, str] = None,
+        build_date: Optional[str] = None,
         summary: str = "",
     ) -> None:
         bundle = result.CheckerBundleType(
@@ -738,7 +738,7 @@ class Result:
 
         return result
 
-    def get_checker_status(self, checker_id: str) -> Union[None, StatusType]:
+    def get_checker_status(self, checker_id: str) -> Optional[StatusType]:
         """
         Return None if the checker is not found.
         """

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -2,7 +2,8 @@ import os
 import pytest
 from lxml import etree
 from pydantic_core import ValidationError
-from qc_baselib.models import config, result
+from datetime import datetime
+from qc_baselib.models import result
 from qc_baselib import Result, IssueSeverity, StatusType, Configuration
 
 
@@ -1503,3 +1504,19 @@ def test_create_rule_id_validation() -> None:
             checker_id="TestChecker",
             rule_uid="test.com:qc:1.0.0:",
         )
+
+
+def test_build_date() -> None:
+    result = Result()
+
+    result.register_checker_bundle(
+        name="TestBundle",
+        description="Example checker bundle",
+        version="0.0.1",
+    )
+
+    checker_bundle_result = result.get_checker_bundle_result("TestBundle")
+
+    print(checker_bundle_result.build_date)
+
+    assert checker_bundle_result.build_date == datetime.now().strftime("%Y-%m-%d")

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1517,6 +1517,4 @@ def test_build_date() -> None:
 
     checker_bundle_result = result.get_checker_bundle_result("TestBundle")
 
-    print(checker_bundle_result.build_date)
-
     assert checker_bundle_result.build_date == datetime.now().strftime("%Y-%m-%d")


### PR DESCRIPTION
**Description**

As discussed in the QC Framework meeting this week, this PR prepares for the release candidate 1.0.0rc1. After this PR is merged into `main`, the tag `v1.0.0-rc1` and the release candidate `1.0.0rc1` for `asam-qc-baselib` will be created.

Other checker bundles will be updated after `asam-qc-baselib` is released, so they can point to `1.0.0rc1`.

**Main changes**

1. Make `build_date` optional when registering a checker bundle. If `build_date` is not provided, use the current execution date as `build_date`.
2. Add disclaimer for `1.0.0rc1`.
3. All the references now point to `main` instead of `develop`.
4. Bump version to `1.0.0rc1`.

**How was the PR tested?**

1. Unit-test

**Notes**
Related issue: https://github.com/asam-ev/qc-opendrive/issues/108