### PR TITLE
added lines argument to add_xml_location

### DIFF
--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -21,6 +21,7 @@ from .common import ParamType, IssueSeverity
 
 class XMLLocationType(BaseXmlModel):
     xpath: str = attr(name="xpath")
+    lines: str = attr(name="lines")
 
 
 class InertialLocationType(BaseXmlModel):

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -503,14 +503,19 @@ class Result:
     ) -> None:
         xml_locations = []
 
-        if isinstance(lines, int):
-            lines_str = str(lines)
-        elif isinstance(lines, list):
-            lines_str = ", ".join([str(line) for line in lines])
-
         if type(xpath) == str:
+            if isinstance(lines, int):
+                lines_str = str(lines)
+            else:
+                raise ValueError("Lines should be an integer when xpath is a string")
             xml_locations.append(result.XMLLocationType(xpath=xpath, lines=lines_str))
         elif type(xpath) == list:
+            if isinstance(lines, list):
+                lines_str = ", ".join([str(line) for line in lines])
+            else:
+                raise ValueError(
+                    "Lines should be a list of integers when xpath is a list"
+                )
             for path in xpath:
                 xml_locations.append(
                     result.XMLLocationType(xpath=path, lines=lines_str)

--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -499,14 +499,22 @@ class Result:
         issue_id: int,
         xpath: Union[str, List[str]],
         description: str,
+        lines: Union[int, List[int]],
     ) -> None:
         xml_locations = []
 
+        if isinstance(lines, int):
+            lines_str = str(lines)
+        elif isinstance(lines, list):
+            lines_str = ", ".join([str(line) for line in lines])
+
         if type(xpath) == str:
-            xml_locations.append(result.XMLLocationType(xpath=xpath))
+            xml_locations.append(result.XMLLocationType(xpath=xpath, lines=lines_str))
         elif type(xpath) == list:
             for path in xpath:
-                xml_locations.append(result.XMLLocationType(xpath=path))
+                xml_locations.append(
+                    result.XMLLocationType(xpath=path, lines=lines_str)
+                )
 
         bundle = self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
 

--- a/tests/data/result_test_output.xqar
+++ b/tests/data/result_test_output.xqar
@@ -8,11 +8,11 @@
           <FileLocation column="0" row="1"/>
         </Locations>
         <Locations description="Location for issue">
-          <XMLLocation xpath="/foo/test/path"/>
+          <XMLLocation xpath="/foo/test/path" lines="5"/>
         </Locations>
         <Locations description="Location for issue with list">
-          <XMLLocation xpath="/foo/test/path"/>
-          <XMLLocation xpath="/bar/test/path"/>
+          <XMLLocation xpath="/foo/test/path" lines="1, 2"/>
+          <XMLLocation xpath="/bar/test/path" lines="1, 2"/>
         </Locations>
         <Locations description="Location for issue">
           <InertialLocation x="1.0" y="2.0" z="3.0"/>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -96,6 +96,7 @@ def test_result_write() -> None:
         issue_id=issue_id,
         xpath="/foo/test/path",
         description="Location for issue",
+        lines=5,
     )
     result.add_xml_location(
         checker_bundle_name="TestBundle",
@@ -103,6 +104,7 @@ def test_result_write() -> None:
         issue_id=issue_id,
         xpath=["/foo/test/path", "/bar/test/path"],
         description="Location for issue with list",
+        lines=[1, 2],
     )
     result.add_inertial_location(
         checker_bundle_name="TestBundle",

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -449,6 +449,7 @@ def test_domain_specific_info_add():
         issue_id=issue_id,
         xpath="/foo/test/path",
         description="Location for issue",
+        lines=1,
     )
 
     result.add_domain_specific_info(


### PR DESCRIPTION
**Description**

Added a "lines" argumnet to the add_xml_location function. This is useful to find the XML element easier in the whole opendrive file.

Usage can be seen in https://github.com/asam-ev/qc-opendrive/pull/124

**Main changes**

1. Added lines attribute to class XMLLocationType
2. Added lines argument to add_xml_location()
3. Test update

**How was the PR tested?**

1. Pytests successful
