### PR TITLE
Make check_id_set optional for all_checkers_completed_without_issue

### DIFF
--- a/qc_baselib/result.py
+++ b/qc_baselib/result.py
@@ -717,34 +717,29 @@ class Result:
                     return True
 
         return False
-    
-    def all_checkers_completed_without_issue(self, check_id_set: Union[None, Set[str]] = None) -> bool:
-        if check_id_set is None:
-            for bundle in self._report_results.checker_bundles:
-                for checker in bundle.checkers:
-                    if checker.status != StatusType.COMPLETED or len(checker.issues) > 0:
-                        return False
-            return True
-        else:
-            checker_id_map = dict()
-            for checker_id in check_id_set:
-                checker_id_map[checker_id] = False
 
-            for bundle in self._report_results.checker_bundles:
-                for checker in bundle.checkers:
-                    if (
-                        checker.checker_id in check_id_set
-                        and checker.status == StatusType.COMPLETED
-                        and len(checker.issues) == 0
-                    ):
-                        checker_id_map[checker.checker_id] = True
+    def all_checkers_completed_without_issue(
+        self, check_id_set: Union[None, Set[str]] = None
+    ) -> bool:
 
-            result = True
+        checker_id_result_map = {
+            checker.checker_id: (
+                checker.status == StatusType.COMPLETED and len(checker.issues) == 0
+            )
+            for bundle in self._report_results.checker_bundles
+            for checker in bundle.checkers
+        }
 
-            for _, checker_result in checker_id_map.items():
-                result = result and checker_result
-
-            return result
+        return not any(
+            [
+                checker_id_result_map.get(id, False) == False
+                for id in (
+                    check_id_set
+                    if check_id_set is not None
+                    else checker_id_result_map.keys()
+                )
+            ]
+        )
 
     def get_checker_status(self, checker_id: str) -> Optional[StatusType]:
         """

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -832,6 +832,8 @@ def test_all_checkers_completed_without_issue() -> None:
         description="",
     )
 
+    assert result_report.all_checkers_completed_without_issue() == False
+
     assert result_report.all_checkers_completed_without_issue({"ThirdChecker"}) == False
 
     assert (
@@ -847,6 +849,7 @@ def test_all_checkers_completed_without_issue() -> None:
         status=StatusType.COMPLETED,
     )
 
+    assert result_report.all_checkers_completed_without_issue() == False
     assert result_report.all_checkers_completed_without_issue({"FirstChecker"}) == True
     assert (
         result_report.all_checkers_completed_without_issue(
@@ -861,6 +864,7 @@ def test_all_checkers_completed_without_issue() -> None:
         status=StatusType.SKIPPED,
     )
 
+    assert result_report.all_checkers_completed_without_issue() == False
     assert result_report.all_checkers_completed_without_issue({"FirstChecker"}) == False
 
     result_report.set_checker_status(
@@ -869,6 +873,7 @@ def test_all_checkers_completed_without_issue() -> None:
         status=StatusType.ERROR,
     )
 
+    assert result_report.all_checkers_completed_without_issue() == False
     assert result_report.all_checkers_completed_without_issue({"FirstChecker"}) == False
 
     result_report.set_checker_status(
@@ -883,12 +888,14 @@ def test_all_checkers_completed_without_issue() -> None:
         status=StatusType.COMPLETED,
     )
 
+    assert result_report.all_checkers_completed_without_issue() == True
     assert (
         result_report.all_checkers_completed_without_issue(
             {"FirstChecker", "SecondChecker"}
         )
         == True
     )
+    assert result_report.all_checkers_completed_without_issue({"ThirdChecker"}) == False
 
     rule_uid_1 = result_report.register_rule(
         checker_bundle_name="TestBundle",
@@ -907,6 +914,7 @@ def test_all_checkers_completed_without_issue() -> None:
         rule_uid=rule_uid_1,
     )
 
+    assert result_report.all_checkers_completed_without_issue() == False
     assert (
         result_report.all_checkers_completed_without_issue(
             {"FirstChecker", "SecondChecker"}


### PR DESCRIPTION
`check_id_set` is now optional and by default set to None. If `check_id_set` is not given, all available checkers are checked until one is not complete or has any issues in which case the method returns False immediately.