### PR TITLE
Make setting of params override any existing one

### DIFF
--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -214,10 +214,6 @@ class Configuration:
         Checker with checker_id will be registered to the checker bundle
         identified by the checker_bundle_name.
         """
-        check = config.CheckerType(
-            checker_id=checker_id, min_level=min_level, max_level=max_level
-        )
-
         if self._configuration is None:
             raise RuntimeError(
                 "Adding check to empty configuration. Initialize the config registering first a checker bundle."
@@ -229,15 +225,27 @@ class Configuration:
                 raise RuntimeError(
                     f"Adding check to non-existent '{checker_bundle_name}' checker bundle. Register first the checker bundle."
                 )
-            check = next(
-                (check for check in bundle.checkers if check.checker_id == checker_id),
-                None,
+            checker = (
+                next(
+                    (
+                        checker
+                        for checker in bundle.checkers
+                        if checker.checker_id == checker_id
+                    ),
+                    None,
+                )
+                if bundle.checkers is not None
+                else None
             )
-            if check is None:
-                bundle.checkers.append(check)
+            if checker is None:
+                bundle.checkers.append(
+                    config.CheckerType(
+                        checker_id=checker_id, min_level=min_level, max_level=max_level
+                    )
+                )
             else:
-                check.min_level = min_level
-                check.max_level = max_level
+                checker.min_level = min_level
+                checker.max_level = max_level
 
     def set_config_param(self, name: str, value: Union[int, float, str]) -> None:
         if self._configuration is None:
@@ -309,18 +317,28 @@ class Configuration:
                     f"Adding param to non-existent '{checker_bundle_name}' checker bundle. Register first the checker bundle."
                 )
 
-            check = next(
-                (check for check in bundle.checkers if check.checker_id == checker_id),
-                None,
+            checker = (
+                next(
+                    (
+                        checker
+                        for checker in bundle.checkers
+                        if checker.checker_id == checker_id
+                    ),
+                    None,
+                )
+                if bundle.checkers is not None
+                else None
             )
-            if check is None:
+            if checker is None:
                 raise RuntimeError(
-                    f"Adding param to non-existent '{checker_bundle_name}' checker bundle. Register first the checker bundle."
+                    f"Adding param to non-existent '{checker_id}' checker. Register first the checker."
                 )
 
-            param = next((param for param in check.params if name == param.name), None)
+            param = next(
+                (param for param in checker.params if name == param.name), None
+            )
             if param is None:
                 param = common.ParamType(name=name, value=value)
-                check.params.append(param)
+                checker.params.append(param)
             else:
                 param.value = value

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -228,18 +228,24 @@ class Configuration:
             bundle.checkers.append(check)
 
     def set_config_param(self, name: str, value: Union[int, float, str]) -> None:
-        param = common.ParamType(name=name, value=value)
-
         if self._configuration is None:
-            self._configuration = config.Config(params=[param])
+            self._configuration = config.Config(
+                params=[common.ParamType(name=name, value=value)]
+            )
         else:
-            self._configuration.params.append(param)
+            param = next(
+                (param for param in self._configuration.params if name == param.name),
+                None,
+            )
+            if param is None:
+                param = common.ParamType(name=name, value=value)
+                self._configuration.params.append(param)
+            else:
+                param.value = value
 
     def set_checker_bundle_param(
         self, checker_bundle_name: str, name: str, value: Union[int, float, str]
     ) -> None:
-        param = common.ParamType(name=name, value=value)
-
         if self._configuration is None:
             raise RuntimeError(
                 "Adding param to empty configuration. Initialize the config registering first an initial element."
@@ -258,7 +264,12 @@ class Configuration:
                 raise RuntimeError(
                     f"Adding param to non-existent '{checker_bundle_name}' checker bundle. Register first the checker bundle."
                 )
-            bundle.params.append(param)
+            param = next((param for param in bundle.params if name == param.name), None)
+            if param is None:
+                param = common.ParamType(name=name, value=value)
+                bundle.params.append(param)
+            else:
+                param.value = value
 
     def set_checker_param(
         self,
@@ -267,8 +278,6 @@ class Configuration:
         name: str,
         value: Union[str, int, float],
     ) -> None:
-        param = common.ParamType(name=name, value=value)
-
         if self._configuration is None:
             raise RuntimeError(
                 "Adding param to empty configuration. Initialize the config registering first an initial element."
@@ -296,4 +305,10 @@ class Configuration:
                 raise RuntimeError(
                     f"Adding param to non-existent '{checker_bundle_name}' checker bundle. Register first the checker bundle."
                 )
-            check.params.append(param)
+
+            param = next((param for param in check.params if name == param.name), None)
+            if param is None:
+                param = common.ParamType(name=name, value=value)
+                check.params.append(param)
+            else:
+                param.value = value

--- a/qc_baselib/configuration.py
+++ b/qc_baselib/configuration.py
@@ -197,7 +197,11 @@ class Configuration:
             )
 
         else:
-            self._configuration.checker_bundles.append(checker_bundle)
+            if (
+                self._get_checker_bundle(checker_bundle_name=checker_bundle_name)
+                is None
+            ):
+                self._configuration.checker_bundles.append(checker_bundle)
 
     def register_checker(
         self,
@@ -225,7 +229,15 @@ class Configuration:
                 raise RuntimeError(
                     f"Adding check to non-existent '{checker_bundle_name}' checker bundle. Register first the checker bundle."
                 )
-            bundle.checkers.append(check)
+            check = next(
+                (check for check in bundle.checkers if check.checker_id == checker_id),
+                None,
+            )
+            if check is None:
+                bundle.checkers.append(check)
+            else:
+                check.min_level = min_level
+                check.max_level = max_level
 
     def set_config_param(self, name: str, value: Union[int, float, str]) -> None:
         if self._configuration is None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -65,15 +65,44 @@ def test_register_checker_bundle() -> None:
     config = Configuration()
 
     config.register_checker_bundle("TestCheckerBundle")
+    assert config._get_checker_bundle("TestCheckerBundle") is not None
+    assert len(config._configuration.checker_bundles) == 1
+    config.register_checker_bundle("TestCheckerBundle")
+    assert config._get_checker_bundle("TestCheckerBundle") is not None
+    assert len(config._configuration.checker_bundles) == 1
 
 
 def test_register_checker_to_bundle() -> None:
     config = Configuration()
 
     config.register_checker_bundle("TestCheckerBundle")
+
+    def get_checker(checker_id: str) -> result.CheckerType | None:
+        bundle = config._get_checker_bundle("TestCheckerBundle")
+        if bundle is None:
+            return None
+        else:
+            if bundle.checkers is None:
+                return None
+            else:
+                for check in bundle.checkers:
+                    if check.checker_id == checker_id:
+                        return check
+        return None
+
+    assert get_checker("TestChecker") is None
     config.register_checker(
         "TestCheckerBundle", "TestChecker", min_level=1, max_level=3
     )
+    assert get_checker("TestChecker") is not None
+    assert len(config._get_checker_bundle("TestCheckerBundle").checkers) == 1
+    assert get_checker("TestChecker").max_level == 3
+    config.register_checker(
+        "TestCheckerBundle", "TestChecker", min_level=1, max_level=4
+    )
+    assert get_checker("TestChecker") is not None
+    assert len(config._get_checker_bundle("TestCheckerBundle").checkers) == 1
+    assert get_checker("TestChecker").max_level == 4
 
 
 def test_set_checker_bundle_param() -> None:


### PR DESCRIPTION
Currently if the set functions are called for an existing parameter, a new param entry is just appended, which will then not take any effect, as we always return the first entry on the getters.

This is not obviously the behavior one would expect from a setter (rather than an appender), hence this PR changes the semantics to properly update the first found existing entry, if present.

This is a minimalistic change, and is still robust against multiple param entries for the same name already existing (e.g. in loaded files), while still ensuring that any newly set parameters override the existing parameter value, which is useful for the checker bundles in handling command-line arguments for overriding of information in the configuration.