### PR TITLE
Adjust patterns, tests for rule id validation

### DIFF
--- a/qc_baselib/models/result.py
+++ b/qc_baselib/models/result.py
@@ -82,14 +82,14 @@ class RuleType(BaseXmlModel):
     rule_full_name: str = attr(
         name="rule_full_name",
         default="",
-        pattern=r"^((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+        pattern=r"^(((\p{L}[\w_]*)\.)*)(\p{L}[\w_]*)$",
         exclude=True,
     )
 
     rule_uid: str = attr(
         name="ruleUID",
         default="",
-        pattern=r"^((\w+(\.\w+)+)):(([a-z]+)):(([0-9]+(\.[0-9]+)+)):((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+        pattern=r"^((\w+(\.\w+)+)):(([a-z]+)):(([0-9]+(\.[0-9]+)+)):(((\p{L}[\w_]*)\.)*)(\p{L}[\w_]*)$",
     )
 
     @model_validator(mode="after")
@@ -172,7 +172,7 @@ class IssueType(
     rule_uid: str = attr(
         name="ruleUID",
         default="",
-        pattern=r"^((\w+(\.\w+)+)):(([a-z]+)):(([0-9]+(\.[0-9]+)+)):((([a-z][\w_]*)\.)*)([a-z][\w_]*)$",
+        pattern=r"^((\w+(\.\w+)+)):(([a-z]+)):(([0-9]+(\.[0-9]+)+)):(((\p{L}[\w_]*)\.)*)(\p{L}[\w_]*)$",
     )
     # Raw is defined here to enable parsing of "any" XML tag inside the domain
     # specific information. It is linked to the DomainSpecificInfoType model

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -273,7 +273,7 @@ def test_create_issue_with_unregistered_rule_id() -> None:
         )
 
 
-def test_create_rule_id_validation() -> None:
+def test_register_rule_id_validation() -> None:
     result = Result()
 
     result.register_checker_bundle(
@@ -289,6 +289,25 @@ def test_create_rule_id_validation() -> None:
         checker_id="TestChecker",
         description="Test checker",
         summary="Executed evaluation",
+    )
+
+    rule_uid = result.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        emanating_entity="test.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="DemoClass.field.is_set",
+    )
+
+    # Test for non-ASCII and non-BMP letters in rule_full_name, i.e. U+00E4 (ä), U+00F6 (ö), U+00FC (ü), U+10403 (𐐃)
+    rule_uid = result.register_rule(
+        checker_bundle_name="TestBundle",
+        checker_id="TestChecker",
+        emanating_entity="test.com",
+        standard="qc",
+        definition_setting="1.0.0",
+        rule_full_name="DemoClass.field.is_set.äöü_𐐃",
     )
 
     with pytest.raises(
@@ -341,6 +360,32 @@ def test_create_rule_id_validation() -> None:
             standard="qc",
             definition_setting="1.0.0",
             rule_full_name="",
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match=r".*\nrule_full_name\n.* String should match pattern .*",
+    ) as exc_info:
+        rule_uid = result.register_rule(
+            checker_bundle_name="TestBundle",
+            checker_id="TestChecker",
+            emanating_entity="test.com",
+            standard="qc",
+            definition_setting="1.0.0",
+            rule_full_name="0demo.rule",
+        )
+
+    with pytest.raises(
+        ValidationError,
+        match=r".*\nrule_full_name\n.* String should match pattern .*",
+    ) as exc_info:
+        rule_uid = result.register_rule(
+            checker_bundle_name="TestBundle",
+            checker_id="TestChecker",
+            emanating_entity="test.com",
+            standard="qc",
+            definition_setting="1.0.0",
+            rule_full_name="demo rule",
         )
 
 
@@ -1441,7 +1486,7 @@ def test_result_register_rule_by_uid() -> None:
     assert rules[0].rule_uid == "test.com:qc:1.0.0:qwerty.qwerty"
 
 
-def test_create_rule_id_validation() -> None:
+def test_register_rule_by_uid_id_validation() -> None:
     result = Result()
 
     result.register_checker_bundle(


### PR DESCRIPTION
This addresses the changes to the format restrictions on rule name components in the framework, fixes a method name duplication in the test cases, and adds tests for some corner cases in the broader format.

Addresses asam-ev/qc-framework#220, see asam-ev/qc-framework#221.
